### PR TITLE
Improved response codes handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ temp.py
 temp/
 1.0/
 venv-activate.sh
+venvcmd.sh

--- a/bookops_worldcat/__version__.py
+++ b/bookops_worldcat/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "bookops-worldcat"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Tomasz Kalata"
 __author_email__ = "klingaroo@gmail.com"

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -8,7 +8,7 @@ import sys
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import requests
-from requests import Response
+from requests import Request, Response
 
 from ._session import WorldcatSession
 from .authorize import WorldcatAccessToken
@@ -18,7 +18,7 @@ from .errors import (
     InvalidOclcNumber,
     WorldcatAuthorizationError,
 )
-from .utils import verify_oclc_number, verify_oclc_numbers, _parse_error_response
+from .utils import verify_oclc_number, verify_oclc_numbers
 
 
 class MetadataSession(WorldcatSession):
@@ -182,8 +182,14 @@ class MetadataSession(WorldcatSession):
         header = {"Accept": "application/json"}
         url = self._url_brief_bib_oclc_number(oclcNumber)
 
-        # send request
+        #  prep & send request
         try:
+            prepared_request = Request(
+                "GET", url, headers=headers, hooks=hooks, timeout=self.timeout
+            )
+
+            response = Query(prepared_request)
+
             response = self.get(url, headers=header, hooks=hooks, timeout=self.timeout)
             if response.status_code == requests.codes.ok:
                 return response

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -18,6 +18,7 @@ from .errors import (
     InvalidOclcNumber,
     WorldcatAuthorizationError,
 )
+from .query import Query
 from .utils import verify_oclc_number, verify_oclc_numbers
 
 
@@ -158,6 +159,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Retrieve specific brief bibliographic resource.
+        Uses /brief-bibs/{oclcNumber} endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be
@@ -167,7 +169,7 @@ class MetadataSession(WorldcatSession):
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
         Returns:
-            `requests.models.Response` object
+            `requests.Response` instance
         """
 
         try:
@@ -182,26 +184,14 @@ class MetadataSession(WorldcatSession):
         header = {"Accept": "application/json"}
         url = self._url_brief_bib_oclc_number(oclcNumber)
 
-        #  prep & send request
-        try:
-            prepared_request = Request(
-                "GET", url, headers=headers, hooks=hooks, timeout=self.timeout
-            )
+        # prep request
+        req = Request("GET", url, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
 
-            response = Query(prepared_request)
+        # send request
+        query = Query(self, prepared_request, timeout=self.timeout)
 
-            response = self.get(url, headers=header, hooks=hooks, timeout=self.timeout)
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        return query.response
 
     def get_full_bib(
         self,
@@ -211,6 +201,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Send a GET request for a full bibliographic resource.
+        Uses /bib/data/{oclcNumber} endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be an
@@ -238,20 +229,14 @@ class MetadataSession(WorldcatSession):
             )
         header = {"Accept": response_format}
 
+        # prep request
+        req = Request("GET", url, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(url, headers=header, hooks=hooks, timeout=self.timeout)
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def holding_get_status(
         self,
@@ -265,6 +250,7 @@ class MetadataSession(WorldcatSession):
         Retrieves Worlcat holdings status of a record with provided OCLC number.
         The service automatically recognizes institution based on the issued access
         token.
+        Uses /ih/checkholdings endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be an
@@ -295,22 +281,14 @@ class MetadataSession(WorldcatSession):
         header = {"Accept": response_format}
         payload = {"oclcNumber": oclcNumber, "inst": inst, "instSymbol": instSymbol}
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def holding_set(
         self,
@@ -324,6 +302,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Sets institution's Worldcat holding on an individual record.
+        Uses /ih/data endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be an
@@ -364,28 +343,14 @@ class MetadataSession(WorldcatSession):
             "classificationScheme": classificationScheme,
         }
 
+        # prep request
+        req = Request("POST", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.post(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == 201:
-                # the service does not return any meaningful response
-                # when holdings are succesfully set
-                return response
-            elif response.status_code == 409:
-                # holdings already set
-                # it seems resonable to simply ignore this response
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def holding_unset(
         self,
@@ -400,6 +365,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Deletes institution's Worldcat holding on an individual record.
+        Uses /ih/data endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be an
@@ -447,28 +413,14 @@ class MetadataSession(WorldcatSession):
             "classificationScheme": classificationScheme,
         }
 
+        # prep request
+        req = Request("DELETE", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.delete(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                # the service does not return any meaningful response
-                # when holdings are succesfully deleted
-                return response
-            elif response.status_code == 409:
-                # holdings already set
-                # it seems resonable to simply ignore this response
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def holdings_set(
         self,
@@ -480,6 +432,7 @@ class MetadataSession(WorldcatSession):
     ) -> List[Response]:
         """
         Set institution holdings for multiple OCLC numbers
+        Uses /ih/datalist endpoint.
 
         Args:
             oclcNumbers:            list of OCLC control numbers for which holdings
@@ -521,30 +474,15 @@ class MetadataSession(WorldcatSession):
             if self.authorization.is_expired():
                 self._get_new_access_token()
 
-            # send request
-            try:
-                response = self.post(
-                    url,
-                    headers=header,
-                    params=payload,
-                    hooks=hooks,
-                    timeout=self.timeout,
-                )
+            # prep request
+            req = Request("POST", url, params=payload, headers=header, hooks=hooks)
+            prepared_request = self.prepare_request(req)
 
-                if response.status_code == 207:
-                    # the service returns multi-status response
-                    responses.append(response)
-                else:
-                    error_msg = _parse_error_response(response)
-                    raise WorldcatRequestError(error_msg)
-            except WorldcatRequestError as exc:
-                raise WorldcatSessionError(exc)
-            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-            except:
-                raise WorldcatSessionError(
-                    f"Unexpected request error: {sys.exc_info()[0]}"
-                )
+            # send request
+            query = Query(self, prepared_request, timeout=self.timeout)
+
+            responses.append(query.response)
+
         return responses
 
     def holdings_unset(
@@ -558,6 +496,7 @@ class MetadataSession(WorldcatSession):
     ) -> List[Response]:
         """
         Set institution holdings for multiple OCLC numbers
+        Uses /ih/datalist endpoint.
 
         Args:
             oclcNumbers:            list of OCLC control numbers for which holdings
@@ -605,30 +544,15 @@ class MetadataSession(WorldcatSession):
             if self.authorization.is_expired():
                 self._get_new_access_token()
 
-            # send request
-            try:
-                response = self.delete(
-                    url,
-                    headers=header,
-                    params=payload,
-                    hooks=hooks,
-                    timeout=self.timeout,
-                )
+            # prep request
+            req = Request("DELETE", url, params=payload, headers=header, hooks=hooks)
+            prepared_request = self.prepare_request(req)
 
-                if response.status_code == 207:
-                    # the service returns multi-status response
-                    responses.append(response)
-                else:
-                    error_msg = _parse_error_response(response)
-                    raise WorldcatRequestError(error_msg)
-            except WorldcatRequestError as exc:
-                raise WorldcatSessionError(exc)
-            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-                raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-            except:
-                raise WorldcatSessionError(
-                    f"Unexpected request error: {sys.exc_info()[0]}"
-                )
+            # send request
+            query = Query(self, prepared_request, timeout=self.timeout)
+
+            responses.append(query.response)
+
         return responses
 
     def search_brief_bib_other_editions(
@@ -665,6 +589,7 @@ class MetadataSession(WorldcatSession):
         """
         Retrieve other editions related to bibliographic resource with provided
         OCLC #.
+        Uses /brief-bibs/{oclcNumber}/other-editions endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be an
@@ -774,22 +699,14 @@ class MetadataSession(WorldcatSession):
             "orderBy": orderBy,
         }
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def search_brief_bibs(
         self,
@@ -816,6 +733,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Send a GET request for brief bibliographic resources.
+        Uses /brief-bibs endpoint.
 
         Args:
             q:                      query in the form of a keyword search or
@@ -869,6 +787,7 @@ class MetadataSession(WorldcatSession):
                                         'recency'
                                         'bestMatch'
                                         'creator'
+                                        'library'
                                         'publicationDateAsc'
                                         'publicationDateDesc'
                                         'mostWidelyHeld'
@@ -916,22 +835,14 @@ class MetadataSession(WorldcatSession):
             "limit": limit,
         }
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatRequestError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def search_current_control_numbers(
         self,
@@ -941,6 +852,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Retrieve current OCLC control numbers
+        Uses /bib/checkcontrolnumbers endpoint.
 
         Args:
             oclcNumbers:            list of OCLC control numbers to be checked;
@@ -970,22 +882,14 @@ class MetadataSession(WorldcatSession):
         url = self._url_bib_check_oclc_numbers()
         payload = {"oclcNumbers": ",".join(vetted_numbers)}
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == 207:  # multi-status response
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def search_general_holdings(
         self,
@@ -1007,6 +911,7 @@ class MetadataSession(WorldcatSession):
     ) -> Response:
         """
         Given a known item gets summary of holdings.
+        Uses /bibs-summary-holdings endpoint.
 
         Args:
             oclcNumber:                 OCLC bibliographic record number; can be
@@ -1074,22 +979,14 @@ class MetadataSession(WorldcatSession):
             "limit": limit,
         }
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Connection error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response
 
     def search_shared_print_holdings(
         self,
@@ -1098,12 +995,15 @@ class MetadataSession(WorldcatSession):
         issn: Optional[str] = None,
         heldByGroup: Optional[str] = None,
         heldInState: Optional[str] = None,
+        itemType: Optional[str] = None,
+        itemSubType: Optional[str] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Response:
         """
         Finds member shared print holdings for specified item.
+        Uses /bibs-retained-holdings endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be
@@ -1115,6 +1015,10 @@ class MetadataSession(WorldcatSession):
             heldByGroup:            restricts to holdings held by group symbol
             heldInState:            restricts to holings held by institutions
                                     in requested state, example: "NY"
+            itemType:               restricts results to specified item type (example
+                                    'book' or 'vis')
+            itemSubType:            restricts results to specified item sub type
+                                    examples: 'book-digital' or 'audiobook-cd'
             offset:                 start position of bibliographic records to
                                     return; default 1
             limit:                  maximum nuber of records to return;
@@ -1151,19 +1055,11 @@ class MetadataSession(WorldcatSession):
             "limit": limit,
         }
 
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
         # send request
-        try:
-            response = self.get(
-                url, headers=header, params=payload, hooks=hooks, timeout=self.timeout
-            )
-            if response.status_code == requests.codes.ok:
-                return response
-            else:
-                error_msg = _parse_error_response(response)
-                raise WorldcatRequestError(error_msg)
-        except WorldcatRequestError as exc:
-            raise WorldcatSessionError(exc)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            raise WorldcatSessionError(f"Request error: {sys.exc_info()[0]}")
-        except:
-            raise WorldcatSessionError(f"Unexpected request error: {sys.exc_info()[0]}")
+        query = Query(self, prepared_request, timeout=self.timeout)
+
+        return query.response

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -41,8 +41,6 @@ class Query:
         except HTTPError as exc:
             raise WorldcatRequestError(f"{exc}")
         except (Timeout, ConnectionError):
-            raise WorldcatRequestError(f"Connection error: {sys.exc_info()[0]}.")
+            raise WorldcatRequestError(f"Connection Error: {sys.exc_info()[0]}")
         except:
-            raise WorldcatRequestError(
-                f"Unexpected request error: {sys.exc_info()[0]}."
-            )
+            raise WorldcatRequestError(f"Unexpected request error: {sys.exc_info()[0]}")

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+"""
+Handles actual requests to OCLC services
+"""
+import sys
+
+from requests import Session
+from requests.models import PreparedRequest
+from requests.exceptions import ConnectionError, HTTPError, Timeout
+
+
+from .errors import WorldcatRequestError
+
+
+class Query:
+    """
+    Sends a request to OClC service and handles any exceptions
+    received.
+    """
+
+    def __init__(
+        self, session: Session, prepared_request: PreparedRequest, timeout: int
+    ) -> None:
+        self.request = prepared_request
+        self.response = None
+
+        self._send(session, timeout)
+
+    def _send(self, session: Session, timeout: int) -> None:
+        try:
+            self.response = session.send(self.request, timeout=timeout)
+            self.response.raise_for_status()
+        except HTTPError as exc:
+            raise WorldcatRequestError(f"{exc}")
+        except (Timeout, ConnectionError):
+            raise WorldcatRequestError(f"Connection error: {sys.exc_info()[0]}.")
+        except:
+            raise WorldcatRequestError(
+                f"Unexpected request error: {sys.exc_info()[0]}."
+            )

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -3,6 +3,7 @@
 """
 Handles actual requests to OCLC services
 """
+from typing import Optional, Union, Tuple
 import sys
 
 from requests import Session
@@ -15,21 +16,27 @@ from .errors import WorldcatRequestError
 
 class Query:
     """
-    Sends a request to OClC service and handles any exceptions
-    received.
+    Sends a request to OClC service and unifies received excepitons
     """
 
     def __init__(
-        self, session: Session, prepared_request: PreparedRequest, timeout: int
+        self,
+        session: Session,
+        prepared_request: PreparedRequest,
+        timeout: Optional[
+            Union[int, float, Tuple[int, int], Tuple[float, float]]
+        ] = None,
     ) -> None:
-        self.request = prepared_request
+        """
+        session:                        `requests.Session` instance
+        prepared_request:               `requests.models.PreparedRequest` instance
+        timeout:                        how long to wait for server to send data before
+                                        giving up
+        """
         self.response = None
 
-        self._send(session, timeout)
-
-    def _send(self, session: Session, timeout: int) -> None:
         try:
-            self.response = session.send(self.request, timeout=timeout)
+            self.response = session.send(prepared_request, timeout=timeout)
             self.response.raise_for_status()
         except HTTPError as exc:
             raise WorldcatRequestError(f"{exc}")

--- a/bookops_worldcat/utils.py
+++ b/bookops_worldcat/utils.py
@@ -6,23 +6,7 @@ Shared utilities module.
 
 from typing import List, Union
 
-from requests import Response
-
 from .errors import InvalidOclcNumber
-
-
-def _parse_error_response(response: Response) -> str:
-    """
-    Parses and formats error responses from OCLC web service
-
-    Args:
-        response: requests.Response obj
-    """
-
-    response.encoding = "utf-8"
-    msg = response.text.strip()
-
-    return f"Web service returned {response.status_code} error: {msg}; {response.url}"
 
 
 def _str2list(s: str) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bookops-worldcat"
-version = "0.4.0"
+version = "0.4.1"
 description = "OCLC WorldCat Metadata APIs wrapper"
 authors = ["Tomasz Kalata <klingaroo@gmail.com>"]
 license = "MIT"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers = 
 	webtest: mark a test hitting live endpoints
 	holdings: mark holdings live endpoint tests
+	http_code: use to pass returned http code in 'mock_session_reponse' fixture that mocks requests

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 markers = 
 	webtest: mark a test hitting live endpoints
 	holdings: mark holdings live endpoint tests
-	http_code: use to pass returned http code in 'mock_session_reponse' fixture that mocks requests
+	http_code: use to pass returned http code to 'mock_session_reponse' fixture that mocks 'requests.Session.send' method

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import requests
 
 from requests import Response
 
-from bookops_worldcat import WorldcatAccessToken
+from bookops_worldcat import WorldcatAccessToken, MetadataSession
 
 
 @pytest.fixture
@@ -124,9 +124,6 @@ def mock_session_response(request, monkeypatch):
     def mock_api_response(*args, http_code=http_code, **kwargs):
         return MockHTTPSessionResponse(http_code=http_code)
 
-    # monkeypatch.setattr(requests.Session, "get", mock_api_response)
-    # monkeypatch.setattr(requests.Session, "post", mock_api_response)
-    # monkeypatch.setattr(requests.Session, "delete", mock_api_response)
     monkeypatch.setattr(requests.Session, "send", mock_api_response)
 
 
@@ -192,6 +189,12 @@ def mock_connectionerror(monkeypatch):
 @pytest.fixture
 def mock_token(mock_credentials, mock_successful_post_token_response):
     return WorldcatAccessToken(**mock_credentials)
+
+
+@pytest.fixture
+def stub_session(mock_token):
+    with MetadataSession(authorization=mock_token) as session:
+        yield session
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import pytest
 import requests
 
+from requests import Response
 
 from bookops_worldcat import WorldcatAccessToken
 
@@ -100,9 +101,11 @@ class MockConnectionError:
         raise requests.exceptions.ConnectionError
 
 
-class MockHTTPSessionResponse:
+class MockHTTPSessionResponse(Response):
     def __init__(self, http_code):
         self.status_code = http_code
+        self.reason = "'foo'"
+        self.url = "https://foo.bar?query"
 
 
 @pytest.fixture
@@ -121,9 +124,10 @@ def mock_session_response(request, monkeypatch):
     def mock_api_response(*args, http_code=http_code, **kwargs):
         return MockHTTPSessionResponse(http_code=http_code)
 
-    monkeypatch.setattr(requests.Session, "get", mock_api_response)
-    monkeypatch.setattr(requests.Session, "post", mock_api_response)
-    monkeypatch.setattr(requests.Session, "delete", mock_api_response)
+    # monkeypatch.setattr(requests.Session, "get", mock_api_response)
+    # monkeypatch.setattr(requests.Session, "post", mock_api_response)
+    # monkeypatch.setattr(requests.Session, "delete", mock_api_response)
+    monkeypatch.setattr(requests.Session, "send", mock_api_response)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,27 +163,21 @@ def mock_failed_post_token_response(monkeypatch):
 def mock_unexpected_error(monkeypatch):
     monkeypatch.setattr("requests.post", MockUnexpectedException)
     monkeypatch.setattr("requests.get", MockUnexpectedException)
-    monkeypatch.setattr("requests.Session.get", MockUnexpectedException)
-    monkeypatch.setattr("requests.Session.post", MockUnexpectedException)
-    monkeypatch.setattr("requests.Session.delete", MockUnexpectedException)
+    monkeypatch.setattr("requests.Session.send", MockUnexpectedException)
 
 
 @pytest.fixture
 def mock_timeout(monkeypatch):
     monkeypatch.setattr("requests.post", MockTimeout)
     monkeypatch.setattr("requests.get", MockTimeout)
-    monkeypatch.setattr("requests.Session.get", MockTimeout)
-    monkeypatch.setattr("requests.Session.post", MockTimeout)
-    monkeypatch.setattr("requests.Session.delete", MockTimeout)
+    monkeypatch.setattr("requests.Session.send", MockTimeout)
 
 
 @pytest.fixture
-def mock_connectionerror(monkeypatch):
+def mock_connection_error(monkeypatch):
     monkeypatch.setattr("requests.post", MockConnectionError)
     monkeypatch.setattr("requests.get", MockConnectionError)
-    monkeypatch.setattr("requests.Session.get", MockConnectionError)
-    monkeypatch.setattr("requests.Session.post", MockConnectionError)
-    monkeypatch.setattr("requests.Session.delete", MockConnectionError)
+    monkeypatch.setattr("requests.Session.send", MockConnectionError)
 
 
 @pytest.fixture

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -303,7 +303,7 @@ class TestWorldcatAccessToken:
             )
 
     def test_post_token_request_connectionerror(
-        self, mock_credentials, mock_connectionerror
+        self, mock_credentials, mock_connection_error
     ):
         creds = mock_credentials
         with pytest.raises(WorldcatAuthorizationError):

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -205,7 +205,7 @@ class TestMockedMetadataSession:
                 == "https://worldcat.org/ih/institutionlist"
             )
 
-    def test_get_brief_bib(self, mock_token, mock_successful_session_get_request):
+    def test_get_brief_bib(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.get_brief_bib(12345).status_code == 200
 
@@ -220,7 +220,7 @@ class TestMockedMetadataSession:
                 session.get_brief_bib(oclcNumber=None)
 
     def test_get_brief_bib_with_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_session_get_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -255,7 +255,7 @@ class TestMockedMetadataSession:
                 session.get_brief_bib(12345)
             assert msg in str(exc.value)
 
-    def test_get_full_bib(self, mock_token, mock_successful_session_get_request):
+    def test_get_full_bib(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.get_full_bib(12345).status_code == 200
 
@@ -269,9 +269,7 @@ class TestMockedMetadataSession:
             with pytest.raises(WorldcatSessionError):
                 session.get_full_bib(oclcNumber=None)
 
-    def test_get_full_bib_with_stale_token(
-        self, mock_token, mock_successful_session_get_request
-    ):
+    def test_get_full_bib_with_stale_token(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
                 datetime.datetime.utcnow() - datetime.timedelta(0, 1),
@@ -305,7 +303,7 @@ class TestMockedMetadataSession:
                 session.get_full_bib(12345)
             assert msg in str(exc.value)
 
-    def test_holding_get_status(self, mock_token, mock_successful_session_get_request):
+    def test_holding_get_status(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.holding_get_status(12345).status_code == 200
 
@@ -320,7 +318,7 @@ class TestMockedMetadataSession:
                 session.holding_get_status(oclcNumber=None)
 
     def test_holding_get_status_with_stale_token(
-        self, mock_token, mock_successful_session_get_request
+        self, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -357,7 +355,8 @@ class TestMockedMetadataSession:
                 session.holding_get_status(12345)
             assert msg in str(exc.value)
 
-    def test_holding_set(self, mock_token, mock_successful_holdings_post_request):
+    @pytest.mark.http_code(201)
+    def test_holding_set(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.holding_set(850940548).status_code == 201
 
@@ -371,9 +370,8 @@ class TestMockedMetadataSession:
             with pytest.raises(WorldcatSessionError):
                 session.holding_set(oclcNumber=None)
 
-    def test_holding_set_stale_token(
-        self, mock_token, mock_successful_holdings_post_request
-    ):
+    @pytest.mark.http_code(201)
+    def test_holding_set_stale_token(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
                 datetime.datetime.utcnow() - datetime.timedelta(0, 1),
@@ -417,7 +415,7 @@ class TestMockedMetadataSession:
                 session.holding_set(850940548)
             assert msg in str(exc.value)
 
-    def test_holding_unset(self, mock_token, mock_successful_holdings_delete_request):
+    def test_holding_unset(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.holding_unset(850940548).status_code == 200
 
@@ -432,7 +430,7 @@ class TestMockedMetadataSession:
                 session.holding_unset(oclcNumber=None)
 
     def test_holding_unset_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_holdings_delete_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -491,9 +489,8 @@ class TestMockedMetadataSession:
             ([850940548, 850940552, 850940554], does_not_raise()),
         ],
     )
-    def test_holdings_set(
-        self, argm, expectation, mock_token, mock_successful_multi_status_request
-    ):
+    @pytest.mark.http_code(207)
+    def test_holdings_set(self, argm, expectation, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             with expectation:
                 session.holdings_set(argm)
@@ -503,8 +500,9 @@ class TestMockedMetadataSession:
             with pytest.raises(TypeError):
                 session.holdings_set()
 
+    @pytest.mark.http_code(207)
     def test_holdings_set_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_multi_status_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -552,9 +550,8 @@ class TestMockedMetadataSession:
             ([850940548, 850940552, 850940554], does_not_raise()),
         ],
     )
-    def test_holdings_unset(
-        self, argm, expectation, mock_token, mock_successful_multi_status_request
-    ):
+    @pytest.mark.http_code(207)
+    def test_holdings_unset(self, argm, expectation, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             with expectation:
                 session.holdings_unset(argm)
@@ -564,8 +561,9 @@ class TestMockedMetadataSession:
             with pytest.raises(TypeError):
                 session.holdings_unset()
 
+    @pytest.mark.http_code(207)
     def test_holdings_unset_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_multi_status_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -600,14 +598,12 @@ class TestMockedMetadataSession:
                 session.holdings_unset([850940548, 850940552, 850940554])
             assert msg in str(exc.value)
 
-    def test_search_brief_bib_other_editions(
-        self, mock_token, mock_successful_session_get_request
-    ):
+    def test_search_brief_bibs_other_editions(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.search_brief_bib_other_editions(12345).status_code == 200
 
     def test_search_brief_bibs_other_editions_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_session_get_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -655,7 +651,7 @@ class TestMockedMetadataSession:
                 session.search_brief_bib_other_editions(oclcNumber=12345)
             assert msg in str(exc.value)
 
-    def test_seach_brief_bibs(self, mock_token, mock_successful_session_get_request):
+    def test_seach_brief_bibs(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.search_brief_bibs(q="ti:Zendegi").status_code == 200
 
@@ -667,7 +663,7 @@ class TestMockedMetadataSession:
             assert "Argument 'q' is requried to construct query." in str(exc.value)
 
     def test_search_brief_bibs_with_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_session_get_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -704,9 +700,8 @@ class TestMockedMetadataSession:
                 session.search_brief_bibs("ti:foo")
             assert msg in str(exc.value)
 
-    def test_seach_current_control_numbers(
-        self, mock_token, mock_successful_multi_status_request
-    ):
+    @pytest.mark.http_code(207)
+    def test_seach_current_control_numbers(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert (
                 session.search_current_control_numbers(
@@ -715,8 +710,9 @@ class TestMockedMetadataSession:
                 == 207
             )
 
+    @pytest.mark.http_code(207)
     def test_seach_current_control_numbers_passed_as_str(
-        self, mock_token, mock_successful_multi_status_request
+        self, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             assert (
@@ -734,8 +730,9 @@ class TestMockedMetadataSession:
                 session.search_current_control_numbers(argm)
             assert err_msg in str(exc.value)
 
+    @pytest.mark.http_code(207)
     def test_search_current_control_numbers_with_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_multi_status_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -776,9 +773,7 @@ class TestMockedMetadataSession:
                 session.search_current_control_numbers(["12345", "65891"])
             assert msg in str(exc.value)
 
-    def test_search_general_holdings(
-        self, mock_token, mock_successful_session_get_request
-    ):
+    def test_search_general_holdings(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert session.search_general_holdings(oclcNumber=12345).status_code == 200
 
@@ -797,7 +792,7 @@ class TestMockedMetadataSession:
             assert msg in str(exc.value)
 
     def test_search_general_holdings_with_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_session_get_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(
@@ -838,9 +833,7 @@ class TestMockedMetadataSession:
                 session.search_general_holdings(oclcNumber=12345)
             assert msg in str(exc.value)
 
-    def test_search_shared_print_holdings(
-        self, mock_token, mock_successful_session_get_request
-    ):
+    def test_search_shared_print_holdings(self, mock_token, mock_session_response):
         with MetadataSession(authorization=mock_token) as session:
             assert (
                 session.search_shared_print_holdings(oclcNumber=12345).status_code
@@ -864,7 +857,7 @@ class TestMockedMetadataSession:
             assert msg in str(exc.value)
 
     def test_search_shared_print_holdings_with_stale_token(
-        self, mock_utcnow, mock_token, mock_successful_session_get_request
+        self, mock_utcnow, mock_token, mock_session_response
     ):
         with MetadataSession(authorization=mock_token) as session:
             session.authorization.token_expires_at = datetime.datetime.strftime(

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -8,7 +8,7 @@ import pytest
 
 
 from bookops_worldcat import MetadataSession, WorldcatAccessToken
-from bookops_worldcat.errors import WorldcatSessionError
+from bookops_worldcat.errors import WorldcatSessionError, WorldcatRequestError
 
 
 @contextmanager
@@ -51,10 +51,9 @@ class TestMockedMetadataSession:
             assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
             assert session.authorization.is_expired() is False
 
-    def test_get_new_access_token_exceptions(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session._get_new_access_token()
+    def test_get_new_access_token_exceptions(self, stub_session, mock_timeout):
+        with pytest.raises(WorldcatSessionError):
+            stub_session._get_new_access_token()
 
     @pytest.mark.parametrize(
         "oclcNumbers,buckets,expectation",
@@ -73,43 +72,36 @@ class TestMockedMetadataSession:
         ],
     )
     def test_split_into_legal_volume(
-        self, mock_token, oclcNumbers, buckets, expectation
+        self, stub_session, oclcNumbers, buckets, expectation
     ):
-        token = mock_token
-        with MetadataSession(authorization=token) as session:
-            assert session._split_into_legal_volume(oclcNumbers) == expectation
+        assert stub_session._split_into_legal_volume(oclcNumbers) == expectation
 
-    def test_url_base(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session._url_base() == "https://worldcat.org"
+    def test_url_base(self, stub_session):
+        assert stub_session._url_base() == "https://worldcat.org"
 
-    def test_url_search_base(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_search_base()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1"
-            )
+    def test_url_search_base(self, stub_session):
+        assert (
+            stub_session._url_search_base()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1"
+        )
 
-    def test_url_shared_print_holdings(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_member_shared_print_holdings()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-retained-holdings"
-            )
+    def test_url_shared_print_holdings(self, stub_session):
+        assert (
+            stub_session._url_member_shared_print_holdings()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-retained-holdings"
+        )
 
-    def test_url_member_general_holdings(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_member_general_holdings()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-summary-holdings"
-            )
+    def test_url_member_general_holdings(self, stub_session):
+        assert (
+            stub_session._url_member_general_holdings()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-summary-holdings"
+        )
 
-    def test_url_brief_bib_search(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_brief_bib_search()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs"
-            )
+    def test_url_brief_bib_search(self, stub_session):
+        assert (
+            stub_session._url_brief_bib_search()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs"
+        )
 
     @pytest.mark.parametrize(
         "argm, expectation",
@@ -124,357 +116,213 @@ class TestMockedMetadataSession:
             ),
         ],
     )
-    def test_url_brief_bib_oclc_number(self, argm, expectation, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_brief_bib_oclc_number(oclcNumber=argm)
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345"
-            )
+    def test_url_brief_bib_oclc_number(self, argm, expectation, stub_session):
+        assert (
+            stub_session._url_brief_bib_oclc_number(oclcNumber=argm)
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345"
+        )
 
-    def test_url_brief_bib_other_editions(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_brief_bib_other_editions(oclcNumber="12345")
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345/other-editions"
-            )
+    def test_url_brief_bib_other_editions(self, stub_session):
+        assert (
+            stub_session._url_brief_bib_other_editions(oclcNumber="12345")
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345/other-editions"
+        )
 
-    def test_url_lhr_control_number(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_lhr_control_number(controlNumber="12345")
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/my-holdings/12345"
-            )
+    def test_url_lhr_control_number(self, stub_session):
+        assert (
+            stub_session._url_lhr_control_number(controlNumber="12345")
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/my-holdings/12345"
+        )
 
-    def test_url_lhr_search(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_lhr_search()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/my-holdings"
-            )
+    def test_url_lhr_search(self, stub_session):
+        assert (
+            stub_session._url_lhr_search()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/my-holdings"
+        )
 
-    def test_url_lhr_shared_print(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_lhr_shared_print()
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/retained-holdings"
-            )
+    def test_url_lhr_shared_print(self, stub_session):
+        assert (
+            stub_session._url_lhr_shared_print()
+            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/retained-holdings"
+        )
 
-    def test_url_bib_oclc_number(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_oclc_number(oclcNumber="12345")
-                == "https://worldcat.org/bib/data/12345"
-            )
+    def test_url_bib_oclc_number(self, stub_session):
+        assert (
+            stub_session._url_bib_oclc_number(oclcNumber="12345")
+            == "https://worldcat.org/bib/data/12345"
+        )
 
-    def test_url_bib_check_oclc_numbers(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_check_oclc_numbers()
-                == "https://worldcat.org/bib/checkcontrolnumbers"
-            )
+    def test_url_bib_check_oclc_numbers(self, stub_session):
+        assert (
+            stub_session._url_bib_check_oclc_numbers()
+            == "https://worldcat.org/bib/checkcontrolnumbers"
+        )
 
-    def test_url_bib_holding_libraries(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_holding_libraries()
-                == "https://worldcat.org/bib/holdinglibraries"
-            )
+    def test_url_bib_holding_libraries(self, stub_session):
+        assert (
+            stub_session._url_bib_holding_libraries()
+            == "https://worldcat.org/bib/holdinglibraries"
+        )
 
-    def test_url_bib_holdings_action(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session._url_bib_holdings_action() == "https://worldcat.org/ih/data"
+    def test_url_bib_holdings_action(self, stub_session):
+        assert stub_session._url_bib_holdings_action() == "https://worldcat.org/ih/data"
 
-    def test_url_bib_holdings_check(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_holdings_check()
-                == "https://worldcat.org/ih/checkholdings"
-            )
+    def test_url_bib_holdings_check(self, stub_session):
+        assert (
+            stub_session._url_bib_holdings_check()
+            == "https://worldcat.org/ih/checkholdings"
+        )
 
-    def test_url_bib_holdings_batch_action(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_holdings_batch_action()
-                == "https://worldcat.org/ih/datalist"
-            )
+    def test_url_bib_holdings_batch_action(self, stub_session):
+        assert (
+            stub_session._url_bib_holdings_batch_action()
+            == "https://worldcat.org/ih/datalist"
+        )
 
-    def test_url_bib_holdings_multi_institution_batch_action(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session._url_bib_holdings_multi_institution_batch_action()
-                == "https://worldcat.org/ih/institutionlist"
-            )
+    def test_url_bib_holdings_multi_institution_batch_action(self, stub_session):
+        assert (
+            stub_session._url_bib_holdings_multi_institution_batch_action()
+            == "https://worldcat.org/ih/institutionlist"
+        )
 
-    def test_get_brief_bib(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.get_brief_bib(12345).status_code == 200
+    @pytest.mark.http_code(200)
+    def test_get_brief_bib(self, stub_session, mock_session_response):
+        assert stub_session.get_brief_bib(12345).status_code == 200
 
-    def test_get_brief_bib_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.get_brief_bib()
+    def test_get_brief_bib_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.get_brief_bib()
 
-    def test_get_brief_bib_None_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_brief_bib(oclcNumber=None)
+    def test_get_brief_bib_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.get_brief_bib(oclcNumber=None)
 
+    @pytest.mark.http_code(200)
     def test_get_brief_bib_with_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.get_brief_bib(oclcNumber=12345)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.get_brief_bib(oclcNumber=12345)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
-    def test_get_brief_bib_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_brief_bib(12345)
+    @pytest.mark.http_code(206)
+    def test_get_brief_bib_odd_206_http_code(self, stub_session, mock_session_response):
+        with does_not_raise():
+            response = stub_session.get_brief_bib(12345)
+        assert response.status_code == 206
 
-    def test_get_brief_bib_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_brief_bib(12345)
+    @pytest.mark.http_code(404)
+    def test_get_brief_bib_404_error_response(
+        self, stub_session, mock_session_response
+    ):
+        with pytest.raises(WorldcatRequestError):
+            stub_session.get_brief_bib(12345)
 
-    def test_get_brief_bib_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_brief_bib(12345)
+    @pytest.mark.http_code(200)
+    def test_get_full_bib(self, stub_session, mock_session_response):
+        assert stub_session.get_full_bib(12345).status_code == 200
 
-    def test_get_brief_bib_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.get_brief_bib(12345)
-            assert msg in str(exc.value)
+    def test_get_full_bib_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.get_full_bib()
 
-    def test_get_full_bib(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.get_full_bib(12345).status_code == 200
+    def test_get_full_bib_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.get_full_bib(oclcNumber=None)
 
-    def test_get_full_bib_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.get_full_bib()
+    @pytest.mark.http_code(200)
+    def test_get_full_bib_with_stale_token(self, stub_session, mock_session_response):
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.get_full_bib(12345)
+        assert stub_session.authorization.is_expired() is False
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert response.status_code == 200
 
-    def test_get_full_bib_None_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_full_bib(oclcNumber=None)
+    @pytest.mark.http_code(200)
+    def test_holding_get_status(self, stub_session, mock_session_response):
+        assert stub_session.holding_get_status(12345).status_code == 200
 
-    def test_get_full_bib_with_stale_token(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.get_full_bib(12345)
-            assert session.authorization.is_expired() is False
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert response.status_code == 200
+    def test_holding_get_status_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holding_get_status()
 
-    def test_get_full_bib_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_full_bib(12345)
+    def test_holding_get_status_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.holding_get_status(oclcNumber=None)
 
-    def test_get_full_bib_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_full_bib(12345)
-
-    def test_get_full_bib_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.get_full_bib(12345)
-
-    def test_get_full_bib_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.get_full_bib(12345)
-            assert msg in str(exc.value)
-
-    def test_holding_get_status(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.holding_get_status(12345).status_code == 200
-
-    def test_holding_get_status_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.holding_get_status()
-
-    def test_holding_get_status_None_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_get_status(oclcNumber=None)
-
+    @pytest.mark.http_code(200)
     def test_holding_get_status_with_stale_token(
-        self, mock_token, mock_session_response
+        self, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.holding_get_status(12345)
-            assert session.authorization.is_expired() is False
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert response.status_code == 200
-
-    def test_holding_get_status_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_get_status(12345)
-
-    def test_holding_get_status_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_get_status(12345)
-
-    def test_holding_get_status_unexpected_error(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_get_status(12345)
-
-    def test_holding_status_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.holding_get_status(12345)
-            assert msg in str(exc.value)
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.holding_get_status(12345)
+        assert stub_session.authorization.is_expired() is False
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert response.status_code == 200
 
     @pytest.mark.http_code(201)
-    def test_holding_set(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.holding_set(850940548).status_code == 201
+    def test_holding_set(self, stub_session, mock_session_response):
+        assert stub_session.holding_set(850940548).status_code == 201
 
-    def test_holding_set_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.holding_set()
+    def test_holding_set_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holding_set()
 
-    def test_holding_set_None_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_set(oclcNumber=None)
+    def test_holding_set_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.holding_set(oclcNumber=None)
 
     @pytest.mark.http_code(201)
-    def test_holding_set_stale_token(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.holding_set(850940548)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 201
+    def test_holding_set_stale_token(self, stub_session, mock_session_response):
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.holding_set(850940548)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 201
 
-    def test_holding_set_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_set(850940548)
+    @pytest.mark.http_code(200)
+    def test_holding_unset(self, stub_session, mock_session_response):
+        assert stub_session.holding_unset(850940548).status_code == 200
 
-    def test_holding_set_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_set(850940548)
+    def test_holding_unset_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holding_unset()
 
-    def test_holding_set_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_set(850940548)
+    def test_holding_unset_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.holding_unset(oclcNumber=None)
 
-    def test_holding_set_409_error_response(self, mock_token, mock_409_response):
-        msg = {
-            "code": {"value": "WS-409", "type": "application"},
-            "message": "Trying to set hold while holding already exists",
-            "detail": None,
-        }
-        with MetadataSession(authorization=mock_token) as session:
-            response = session.holding_set(850940548)
-            assert response.json() == msg
-
-    def test_holding_set_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.holding_set(850940548)
-            assert msg in str(exc.value)
-
-    def test_holding_unset(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.holding_unset(850940548).status_code == 200
-
-    def test_holding_unset_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.holding_unset()
-
-    def test_holding_unset_None_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_unset(oclcNumber=None)
-
+    @pytest.mark.http_code(200)
     def test_holding_unset_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.holding_unset(850940548)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
-
-    def test_holding_unset_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_unset(850940548)
-
-    def test_holding_unset_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_unset(850940548)
-
-    def test_holding_unset_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_unset(850940548)
-
-    def test_holding_unset_409_error_response(self, mock_token, mock_409_response):
-        # cheating here a bit, response is bit different
-        msg = {
-            "code": {"value": "WS-409", "type": "application"},
-            "message": "Trying to set hold while holding already exists",
-            "detail": None,
-        }
-        with MetadataSession(authorization=mock_token) as session:
-            response = session.holding_unset(850940548)
-            assert response.json() == msg
-
-    def test_holding_unset_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.holding_unset(850940548)
-            assert msg in str(exc.value)
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.holding_unset(850940548)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
     @pytest.mark.parametrize(
         "argm,expectation",
@@ -490,52 +338,27 @@ class TestMockedMetadataSession:
         ],
     )
     @pytest.mark.http_code(207)
-    def test_holdings_set(self, argm, expectation, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            with expectation:
-                session.holdings_set(argm)
+    def test_holdings_set(self, argm, expectation, stub_session, mock_session_response):
+        with expectation:
+            stub_session.holdings_set(argm)
 
-    def test_holdings_set_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.holdings_set()
+    def test_holdings_set_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_set()
 
     @pytest.mark.http_code(207)
     def test_holdings_set_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            with does_not_raise():
-                assert session.authorization.is_expired() is True
-                session.holdings_set([850940548, 850940552, 850940554])
-                assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-                assert session.authorization.is_expired() is False
-
-    def test_holdings_set_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holdings_set([850940548, 850940552, 850940554])
-
-    def test_holdings_set_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_set([850940548, 850940552, 850940554])
-
-    def test_holdings_set_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holdings_set([850940548, 850940552, 850940554])
-
-    def test_holdings_set_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.holdings_set([850940548, 850940552, 850940554])
-            assert msg in str(exc.value)
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        with does_not_raise():
+            assert stub_session.authorization.is_expired() is True
+            stub_session.holdings_set([850940548, 850940552, 850940554])
+            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.parametrize(
         "argm,expectation",
@@ -551,352 +374,185 @@ class TestMockedMetadataSession:
         ],
     )
     @pytest.mark.http_code(207)
-    def test_holdings_unset(self, argm, expectation, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            with expectation:
-                session.holdings_unset(argm)
+    def test_holdings_unset(
+        self, argm, expectation, stub_session, mock_session_response
+    ):
+        with expectation:
+            stub_session.holdings_unset(argm)
 
-    def test_holdings_unset_no_oclcNumber_passed(self, mock_token):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(TypeError):
-                session.holdings_unset()
+    def test_holdings_unset_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_unset()
 
     @pytest.mark.http_code(207)
     def test_holdings_unset_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            with does_not_raise():
-                assert session.authorization.is_expired() is True
-                session.holdings_unset([850940548, 850940552, 850940554])
-                assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-                assert session.authorization.is_expired() is False
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        with does_not_raise():
+            assert stub_session.authorization.is_expired() is True
+            stub_session.holdings_unset([850940548, 850940552, 850940554])
+            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.is_expired() is False
 
-    def test_holdings_uset_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holdings_unset([850940548, 850940552, 850940554])
+    @pytest.mark.http_code(200)
+    def test_search_brief_bibs_other_editions(
+        self, stub_session, mock_session_response
+    ):
+        assert stub_session.search_brief_bib_other_editions(12345).status_code == 200
 
-    def test_holdings_unset_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holding_unset([850940548, 850940552, 850940554])
-
-    def test_holdings_unset_unexpected_error(self, mock_token, mock_unexpected_error):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.holdings_unset([850940548, 850940552, 850940554])
-
-    def test_holdings_unset_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.holdings_unset([850940548, 850940552, 850940554])
-            assert msg in str(exc.value)
-
-    def test_search_brief_bibs_other_editions(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.search_brief_bib_other_editions(12345).status_code == 200
-
+    @pytest.mark.http_code(200)
     def test_search_brief_bibs_other_editions_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.search_brief_bib_other_editions(12345)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.search_brief_bib_other_editions(12345)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
-    def test_search_brief_bib_other_editions_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bib_other_editions(12345)
-
-    def test_search_brief_bib_other_editions_connectionerror(
-        self, mock_token, mock_connectionerror
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bib_other_editions(12345)
-
-    def test_search_brief_bib_other_editions_unexpected_error(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bib_other_editions(12345)
-
-    def test_search_brief_bibs_other_editions_invalid_oclc_number(self, mock_token):
+    def test_search_brief_bibs_other_editions_invalid_oclc_number(self, stub_session):
         msg = "Invalid OCLC # was passed as an argument"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_brief_bib_other_editions("odn12345")
-            assert msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_brief_bib_other_editions("odn12345")
+        assert msg in str(exc.value)
 
-    def test_search_brief_bib_other_editions_400_error_response(
-        self, mock_token, mock_400_response
-    ):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_brief_bib_other_editions(oclcNumber=12345)
-            assert msg in str(exc.value)
-
-    def test_seach_brief_bibs(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.search_brief_bibs(q="ti:Zendegi").status_code == 200
+    @pytest.mark.http_code(200)
+    def test_seach_brief_bibs(self, stub_session, mock_session_response):
+        assert stub_session.search_brief_bibs(q="ti:Zendegi").status_code == 200
 
     @pytest.mark.parametrize("argm", [(None), ("")])
-    def test_search_brief_bibs_missing_query(self, mock_token, argm):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_brief_bibs(argm)
-            assert "Argument 'q' is requried to construct query." in str(exc.value)
+    def test_search_brief_bibs_missing_query(self, stub_session, argm):
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_brief_bibs(argm)
+        assert "Argument 'q' is requried to construct query." in str(exc.value)
 
+    @pytest.mark.http_code(200)
     def test_search_brief_bibs_with_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.search_brief_bibs(q="ti:foo")
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
-
-    def test_search_brief_bibs_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bibs("ti:foo")
-
-    def test_search_brief_bibs_connectionerror(self, mock_token, mock_connectionerror):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bibs("ti:foo")
-
-    def test_search_brief_bibs_unexpected_error(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_brief_bibs("ti:foo")
-
-    def test_search_brief_bibs_400_error_response(self, mock_token, mock_400_response):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_brief_bibs("ti:foo")
-            assert msg in str(exc.value)
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.search_brief_bibs(q="ti:foo")
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
     @pytest.mark.http_code(207)
-    def test_seach_current_control_numbers(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session.search_current_control_numbers(
-                    oclcNumbers=["12345", "65891"]
-                ).status_code
-                == 207
-            )
+    def test_seach_current_control_numbers(self, stub_session, mock_session_response):
+        assert (
+            stub_session.search_current_control_numbers(
+                oclcNumbers=["12345", "65891"]
+            ).status_code
+            == 207
+        )
 
     @pytest.mark.http_code(207)
     def test_seach_current_control_numbers_passed_as_str(
-        self, mock_token, mock_session_response
+        self, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session.search_current_control_numbers(
-                    oclcNumbers="12345,65891"
-                ).status_code
-                == 207
-            )
+        assert (
+            stub_session.search_current_control_numbers(
+                oclcNumbers="12345,65891"
+            ).status_code
+            == 207
+        )
 
     @pytest.mark.parametrize("argm", [(None), (""), ([])])
-    def test_search_current_control_numbers_missing_numbers(self, mock_token, argm):
+    def test_search_current_control_numbers_missing_numbers(self, stub_session, argm):
         err_msg = "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #."
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_current_control_numbers(argm)
-            assert err_msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_current_control_numbers(argm)
+        assert err_msg in str(exc.value)
 
     @pytest.mark.http_code(207)
     def test_search_current_control_numbers_with_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.search_current_control_numbers(["12345", "65891"])
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 207
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.search_current_control_numbers(["12345", "65891"])
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 207
 
-    def test_search_current_control_numbers_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_current_control_numbers(["12345", "65891"])
+    @pytest.mark.http_code(200)
+    def test_search_general_holdings(self, stub_session, mock_session_response):
+        assert stub_session.search_general_holdings(oclcNumber=12345).status_code == 200
 
-    def test_search_current_control_numbers_connectionerror(
-        self, mock_token, mock_connectionerror
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_current_control_numbers(["12345", "65891"])
-
-    def test_search_current_control_numbers_unexpected_error(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_current_control_numbers(["12345", "65891"])
-
-    def test_search_current_control_numbers_400_error_response(
-        self, mock_token, mock_400_response
-    ):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_current_control_numbers(["12345", "65891"])
-            assert msg in str(exc.value)
-
-    def test_search_general_holdings(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert session.search_general_holdings(oclcNumber=12345).status_code == 200
-
-    def test_search_general_holdings_missing_arguments(self, mock_token):
+    def test_search_general_holdings_missing_arguments(self, stub_session):
         msg = "Missing required argument. One of the following args are required: oclcNumber, issn, isbn"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_general_holdings(holdingsAllEditions=True, limit=20)
-            assert msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_general_holdings(holdingsAllEditions=True, limit=20)
+        assert msg in str(exc.value)
 
-    def test_search_general_holdings_invalid_oclc_number(self, mock_token):
+    def test_search_general_holdings_invalid_oclc_number(self, stub_session):
         msg = "Invalid OCLC # was passed as an argument"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_general_holdings(oclcNumber="odn12345")
-            assert msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_general_holdings(oclcNumber="odn12345")
+        assert msg in str(exc.value)
 
+    @pytest.mark.http_code(200)
     def test_search_general_holdings_with_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.search_general_holdings(oclcNumber=12345)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.search_general_holdings(oclcNumber=12345)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
-    def test_search_general_holdings_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_general_holdings(oclcNumber="12345")
+    @pytest.mark.http_code(200)
+    def test_search_shared_print_holdings(self, stub_session, mock_session_response):
+        assert (
+            stub_session.search_shared_print_holdings(oclcNumber=12345).status_code
+            == 200
+        )
 
-    def test_search_general_holdings_connectionerror(
-        self, mock_token, mock_connectionerror
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_general_holdings(oclcNumber=12345)
-
-    def test_search_general_holdings_unexpectederror(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_general_holdings(oclcNumber="12345")
-
-    def test_search_general_holdings_400_error_response(
-        self, mock_token, mock_400_response
-    ):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_general_holdings(oclcNumber=12345)
-            assert msg in str(exc.value)
-
-    def test_search_shared_print_holdings(self, mock_token, mock_session_response):
-        with MetadataSession(authorization=mock_token) as session:
-            assert (
-                session.search_shared_print_holdings(oclcNumber=12345).status_code
-                == 200
-            )
-
-    def test_search_shared_print_holdings_missing_arguments(self, mock_token):
+    def test_search_shared_print_holdings_missing_arguments(self, stub_session):
         msg = "Missing required argument. One of the following args are required: oclcNumber, issn, isbn"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_shared_print_holdings(heldInState="NY", limit=20)
-            assert msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_shared_print_holdings(heldInState="NY", limit=20)
+        assert msg in str(exc.value)
 
     def test_search_shared_print_holdings_with_invalid_oclc_number_passsed(
-        self, mock_token
+        self, stub_session
     ):
         msg = "Invalid OCLC # was passed as an argument"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_shared_print_holdings(oclcNumber="odn12345")
-            assert msg in str(exc.value)
+        with pytest.raises(WorldcatSessionError) as exc:
+            stub_session.search_shared_print_holdings(oclcNumber="odn12345")
+        assert msg in str(exc.value)
 
+    @pytest.mark.http_code(200)
     def test_search_shared_print_holdings_with_stale_token(
-        self, mock_utcnow, mock_token, mock_session_response
+        self, mock_utcnow, stub_session, mock_session_response
     ):
-        with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
-            )
-            assert session.authorization.is_expired() is True
-            response = session.search_shared_print_holdings(oclcNumber=12345)
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
-
-    def test_search_shared_print_holdings_timeout(self, mock_token, mock_timeout):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_shared_print_holdings(oclcNumber="12345")
-
-    def test_search_shared_print_holdings_connectionerror(
-        self, mock_token, mock_connectionerror
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_shared_print_holdings(oclcNumber=12345)
-
-    def test_search_shared_print_holdings_unexpectederror(
-        self, mock_token, mock_unexpected_error
-    ):
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError):
-                session.search_shared_print_holdings(oclcNumber="12345")
-
-    def test_search_shared_print_holdings_400_error_response(
-        self, mock_token, mock_400_response
-    ):
-        msg = "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        with MetadataSession(authorization=mock_token) as session:
-            with pytest.raises(WorldcatSessionError) as exc:
-                session.search_shared_print_holdings(oclcNumber=12345)
-            assert msg in str(exc.value)
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        assert stub_session.authorization.is_expired() is True
+        response = stub_session.search_shared_print_holdings(oclcNumber=12345)
+        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.is_expired() is False
+        assert response.status_code == 200
 
 
 @pytest.mark.webtest
@@ -913,6 +569,7 @@ class TestLiveMetadataSession:
                 "generalFormat",
                 "isbns",
                 "language",
+                "machineReadableDate",
                 "mergedOclcNumbers",
                 "oclcNumber",
                 "publicationPlace",
@@ -945,13 +602,13 @@ class TestLiveMetadataSession:
             principal_idns=os.getenv("WCPrincipalIDNS"),
         )
         token.token_str = "invalid-token"
-        err_msg = 'Web service returned 401 error: {"message":"Unauthorized"}; https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045'
+        err_msg = "401 Client Error: Unauthorized for url: https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
         with MetadataSession(authorization=token) as session:
             session.headers.update({"Authorization": f"Bearer invalid-token"})
-            with pytest.raises(WorldcatSessionError) as exc:
+            with pytest.raises(WorldcatRequestError) as exc:
                 session.get_brief_bib(41266045)
 
-            assert err_msg in str(exc.value)
+            assert err_msg == str(exc.value)
 
     def test_get_brief_bib_with_stale_token(self, live_keys):
         token = WorldcatAccessToken(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pytest
+
+from requests import Request
+
+from bookops_worldcat.errors import WorldcatRequestError
+from bookops_worldcat.query import Query
+from bookops_worldcat.metadata_api import MetadataSession, WorldcatAccessToken
+
+
+@pytest.mark.webtest
+def test_temp(live_keys):
+    token = WorldcatAccessToken(
+        key=os.getenv("WCKey"),
+        secret=os.getenv("WCSecret"),
+        scopes=os.getenv("WCScopes"),
+        principal_id=os.getenv("WCPrincipalID"),
+        principal_idns=os.getenv("WCPrincipalIDNS"),
+    )
+    with MetadataSession(authorization=token) as session:
+        header = {"Accept": "application/json"}
+        url = "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
+        req = Request(
+            "GET",
+            url,
+            headers=header,
+        )
+        prepped = session.prepare_request(req)
+
+        query = Query(session, prepped, 2)
+        print(query.response.status_code)
+        print(query.response.url)
+        print(query.response.request.headers)
+        print(query.response.json())
+
+
+@pytest.mark.http_code(404)
+def test_temp2(mock_token, mock_session_response):
+    with MetadataSession(authorization=mock_token) as session:
+        header = {"Accept": "application/json"}
+        url = "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
+        req = Request(
+            "GET",
+            url,
+            headers=header,
+        )
+        prepped = session.prepare_request(req)
+
+        with pytest.raises(WorldcatRequestError) as exc:
+            query = Query(session, prepped, 2)
+
+        assert "404 Client Error: 'foo' for url: https://foo.bar?query" in str(
+            exc.value
+        )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -36,6 +36,13 @@ def test_query_live(live_keys):
         assert query.response.status_code == 200
 
 
+def test_query_not_prepared_request(stub_session):
+    with pytest.raises(AttributeError) as exc:
+        req = Request("GET", "https://foo.org")
+        Query(stub_session, req, timeout=2)
+    assert "Invalid type for argument 'prepared_request'." in str(exc.value)
+
+
 @pytest.mark.http_code(200)
 def test_query_http_200_response(stub_session, mock_session_response):
     with does_not_raise():
@@ -124,3 +131,13 @@ def test_query_unexpected_exception(stub_session, mock_unexpected_error):
         Query(stub_session, prepped)
 
     assert "Unexpected request error: <class 'Exception'>" in str(exc.value)
+
+
+@pytest.mark.http_code(409)
+def test_query_holding_endpoint_409_http_code(stub_session, mock_session_response):
+    req = Request("POST", "https://worldcat.org/ih/data", params={"foo": "bar"})
+    prepped = stub_session.prepare_request(req)
+    with does_not_raise():
+        query = Query(stub_session, prepped)
+
+    assert query.response.status_code == 409

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,7 +12,7 @@ from bookops_worldcat.metadata_api import MetadataSession, WorldcatAccessToken
 
 
 @pytest.mark.webtest
-def test_live_query(live_keys):
+def test_query_live(live_keys):
     token = WorldcatAccessToken(
         key=os.getenv("WCKey"),
         secret=os.getenv("WCSecret"),
@@ -36,8 +36,44 @@ def test_live_query(live_keys):
         assert query.response.status_code == 200
 
 
+@pytest.mark.http_code(200)
+def test_query_http_200_response(stub_session, mock_session_response):
+    with does_not_raise():
+        req = Request("GET", "https://foo.org")
+        prepped = stub_session.prepare_request(req)
+        query = Query(stub_session, prepped)
+        assert query.response.status_code == 200
+
+
+@pytest.mark.http_code(201)
+def test_query_http_201_response(stub_session, mock_session_response):
+    with does_not_raise():
+        req = Request("GET", "https://foo.org")
+        prepped = stub_session.prepare_request(req)
+        query = Query(stub_session, prepped)
+        assert query.response.status_code == 201
+
+
+@pytest.mark.http_code(206)
+def test_query_http_206_response(stub_session, mock_session_response):
+    with does_not_raise():
+        req = Request("GET", "https://foo.org")
+        prepped = stub_session.prepare_request(req)
+        query = Query(stub_session, prepped)
+        assert query.response.status_code == 206
+
+
+@pytest.mark.http_code(207)
+def test_query_http_207_response(stub_session, mock_session_response):
+    with does_not_raise():
+        req = Request("GET", "https://foo.org")
+        prepped = stub_session.prepare_request(req)
+        query = Query(stub_session, prepped)
+        assert query.response.status_code == 207
+
+
 @pytest.mark.http_code(404)
-def test_http_error_query(stub_session, mock_session_response):
+def test_query_http_404_response(stub_session, mock_session_response):
     header = {"Accept": "application/json"}
     url = (
         "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
@@ -46,11 +82,45 @@ def test_http_error_query(stub_session, mock_session_response):
     prepped = stub_session.prepare_request(req)
 
     with pytest.raises(WorldcatRequestError) as exc:
-        query = Query(stub_session, prepped)
+        Query(stub_session, prepped)
 
     assert "404 Client Error: 'foo' for url: https://foo.bar?query" in str(exc.value)
 
 
-# @pytest.mark.http_code(200)
-# def test_http_200_code_query(mock_token, mock_session_response):
-#     with
+@pytest.mark.http_code(500)
+def test_query_http_500_response(stub_session, mock_session_response):
+    req = Request("GET", "https://foo.org")
+    prepped = stub_session.prepare_request(req)
+    with pytest.raises(WorldcatRequestError) as exc:
+        Query(stub_session, prepped)
+
+    assert "500 Server Error: 'foo' for url: https://foo.bar?query" in str(exc.value)
+
+
+def test_query_timeout_exception(stub_session, mock_timeout):
+    req = Request("GET", "https://foo.org")
+    prepped = stub_session.prepare_request(req)
+    with pytest.raises(WorldcatRequestError) as exc:
+        Query(stub_session, prepped)
+
+    assert "Connection Error: <class 'requests.exceptions.Timeout'>" in str(exc.value)
+
+
+def test_query_connection_exception(stub_session, mock_connection_error):
+    req = Request("GET", "https://foo.org")
+    prepped = stub_session.prepare_request(req)
+    with pytest.raises(WorldcatRequestError) as exc:
+        Query(stub_session, prepped)
+
+    assert "Connection Error: <class 'requests.exceptions.ConnectionError'>" in str(
+        exc.value
+    )
+
+
+def test_query_unexpected_exception(stub_session, mock_unexpected_error):
+    req = Request("GET", "https://foo.org")
+    prepped = stub_session.prepare_request(req)
+    with pytest.raises(WorldcatRequestError) as exc:
+        Query(stub_session, prepped)
+
+    assert "Unexpected request error: <class 'Exception'>" in str(exc.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,28 +4,11 @@ import pytest
 
 from bookops_worldcat.utils import (
     _str2list,
-    _parse_error_response,
     prep_oclc_number_str,
     verify_oclc_number,
     verify_oclc_numbers,
 )
 from bookops_worldcat.errors import InvalidOclcNumber
-
-
-class MockServiceErrorResponse:
-    """Simulates error response from the web service"""
-
-    def __init__(self):
-        self.status_code = 400
-        self.url = "https://test.org/some_endpoint"
-        self.text = "{'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}"
-
-    def json(self):
-        return {
-            "type": "MISSING_QUERY_PARAMETER",
-            "title": "Validation Failure",
-            "detail": "details here",
-        }
 
 
 class TestUtils:
@@ -162,10 +145,3 @@ class TestUtils:
     )
     def test_verify_oclc_numbers_parsing(self, argm, expectation):
         assert verify_oclc_numbers(argm) == expectation
-
-    def test_parse_error_response(self):
-        response = MockServiceErrorResponse()
-        assert (
-            _parse_error_response(response)
-            == "Web service returned 400 error: {'type': 'MISSING_QUERY_PARAMETER', 'title': 'Validation Failure', 'detail': 'details here'}; https://test.org/some_endpoint"
-        )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,7 +10,7 @@ from bookops_worldcat.__version__ import (
 
 
 def test_version():
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.4.1"
 
 
 def test_title():

--- a/venvcmd.sh
+++ b/venvcmd.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-source C:/Users/tomaszkalata/AppData/Local/pypoetry/Cache/virtualenvs/bookops-worldcat--3vTmfeo-py3.8/scripts/activate


### PR DESCRIPTION
Fixes https://github.com/BookOps-CAT/bookops-worldcat/issues/32

Any 2xx HTTP responses received from the service do not raise an exception.
Involves major refactoring in `metadata_api` module and related tests that moves actual requests to new `query.Query` class. 