### PR TITLE
Institutionlist endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ At the moment, BookOps-Worldcat supports requests to following OCLC's web servic
         + retrieve holding status of a single resource
         + set institution holdings for a batch of resources
         + unset institution holdings for a batch of resouces
+        + set holdings for a single resource for multiple institutions
+        + unset holdings for a single resource for multiple institutions
 
 
 #### Basic usage:
@@ -160,6 +162,5 @@ Please use [Github issue tracker](https://github.com/BookOps-CAT/bookops-worldca
 + Metadata API:
   + support for local holdings resources endpoints of the search functionality of the Metadata API
   + support for local bibliographic data endpoints
-  + support for holdings batch actions for multiple institutions
   + record validation endpoints
   + methods to create and update bibliographic records

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ with MetadataSession(authorization=token) as session:
 
 ## Changelog
 
-Consult the [Changelog page](https://bookops-cat.github.io/bookops-worldcat/0.3/changelog/) for fixes and enhancements of each version.
+Consult the [Changelog page](https://bookops-cat.github.io/bookops-worldcat/latest/changelog/) for fixes and enhancements of each version.
 
 ## Bugs/Requests
 

--- a/bookops_worldcat/__version__.py
+++ b/bookops_worldcat/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "bookops-worldcat"
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "Tomasz Kalata"
 __author_email__ = "klingaroo@gmail.com"

--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -10,7 +10,8 @@ from typing import Optional, Tuple, Union
 import requests
 
 from . import __title__, __version__  # type: ignore
-from bookops_worldcat.errors import WorldcatSessionError
+from .authorize import WorldcatAccessToken
+from .errors import WorldcatSessionError, WorldcatAuthorizationError
 
 
 class WorldcatSession(requests.Session):
@@ -18,12 +19,28 @@ class WorldcatSession(requests.Session):
 
     def __init__(
         self,
+        authorization: WorldcatAccessToken,
         agent: Optional[str] = None,
         timeout: Optional[
             Union[int, float, Tuple[int, int], Tuple[float, float]]
         ] = None,
     ) -> None:
-        requests.Session.__init__(self)
+        """
+        Args:
+            authorization:          WorldcatAccessToken instance
+            agent:                  "User-agent" parameter to attached to each
+                                    request in the session
+            timeout:                how long to wait for server to send data
+                                    before giving up
+        """
+        super().__init__()
+
+        self.authorization = authorization
+
+        if not isinstance(self.authorization, WorldcatAccessToken):
+            raise WorldcatSessionError(
+                "Argument 'authorization' must be 'WorldcatAccessToken' object."
+            )
 
         if agent is None:
             self.headers.update({"User-Agent": f"{__title__}/{__version__}"})
@@ -36,3 +53,19 @@ class WorldcatSession(requests.Session):
             self.timeout = (5, 5)
         else:
             self.timeout = timeout  # type: ignore
+
+        self._update_authorization()
+
+    def _get_new_access_token(self) -> None:
+        """
+        Allows to continue sending request with new access token after
+        the previous one expired
+        """
+        try:
+            self.authorization._request_token()
+            self._update_authorization()
+        except WorldcatAuthorizationError as exc:
+            raise WorldcatSessionError(exc)
+
+    def _update_authorization(self) -> None:
+        self.headers.update({"Authorization": f"Bearer {self.authorization.token_str}"})

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -176,7 +176,7 @@ class WorldcatAccessToken:
             )
             self.token_type = response.json()["token_type"]
         else:
-            raise WorldcatAuthorizationError(response.json())
+            raise WorldcatAuthorizationError(response.content)
 
     def _payload(self) -> Dict[str, str]:
         """Preps requests params"""
@@ -252,4 +252,6 @@ class WorldcatAccessToken:
             raise
 
     def __repr__(self):
-        return f"access_token: '{self.token_str}', token_type: '{self.token_type}', expires_at: '{self.token_expires_at}'"
+        return (
+            f"access_token: '{self.token_str}', expires_at: '{self.token_expires_at}'"
+        )

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -250,3 +250,6 @@ class WorldcatAccessToken:
             raise
         except ValueError:
             raise
+
+    def __repr__(self):
+        return f"access_token: '{self.token_str}', token_type: '{self.token_type}', expires_at: '{self.token_expires_at}'"

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -514,6 +514,8 @@ class MetadataSession(WorldcatSession):
         except InvalidOclcNumber:
             raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
 
+        url = self._url_bib_holdings_multi_institution_batch_action()
+
     def search_brief_bib_other_editions(
         self,
         oclcNumber: Union[int, str],

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -177,10 +177,6 @@ class MetadataSession(WorldcatSession):
         except InvalidOclcNumber:
             raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
 
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
-
         header = {"Accept": "application/json"}
         url = self._url_brief_bib_oclc_number(oclcNumber)
 
@@ -217,10 +213,6 @@ class MetadataSession(WorldcatSession):
             oclcNumber = verify_oclc_number(oclcNumber)
         except InvalidOclcNumber:
             raise WorldcatSessionError("Invalid OCLC # was passed as an argument.")
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         url = self._url_bib_oclc_number(oclcNumber)
         if not response_format:
@@ -273,10 +265,6 @@ class MetadataSession(WorldcatSession):
         except InvalidOclcNumber as exc:
             raise WorldcatSessionError(exc)
 
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
-
         url = self._url_bib_holdings_check()
         header = {"Accept": response_format}
         payload = {"oclcNumber": oclcNumber, "inst": inst, "instSymbol": instSymbol}
@@ -328,10 +316,6 @@ class MetadataSession(WorldcatSession):
             oclcNumber = verify_oclc_number(oclcNumber)
         except InvalidOclcNumber as exc:
             raise WorldcatSessionError(exc)
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         url = self._url_bib_holdings_action()
         header = {"Accept": response_format}
@@ -397,10 +381,6 @@ class MetadataSession(WorldcatSession):
             oclcNumber = verify_oclc_number(oclcNumber)
         except InvalidOclcNumber as exc:
             raise WorldcatSessionError(exc)
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         url = self._url_bib_holdings_action()
         header = {"Accept": response_format}
@@ -470,10 +450,6 @@ class MetadataSession(WorldcatSession):
                 "instSymbol": instSymbol,
             }
 
-            # make sure access token is still valid and if not request a new one
-            if self.authorization.is_expired():
-                self._get_new_access_token()
-
             # prep request
             req = Request("POST", url, params=payload, headers=header, hooks=hooks)
             prepared_request = self.prepare_request(req)
@@ -539,10 +515,6 @@ class MetadataSession(WorldcatSession):
                 "inst": inst,
                 "instSymbol": instSymbol,
             }
-
-            # make sure access token is still valid and if not request a new one
-            if self.authorization.is_expired():
-                self._get_new_access_token()
 
             # prep request
             req = Request("DELETE", url, params=payload, headers=header, hooks=hooks)
@@ -664,10 +636,6 @@ class MetadataSession(WorldcatSession):
             oclcNumber = verify_oclc_number(oclcNumber)
         except InvalidOclcNumber:
             raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         url = self._url_brief_bib_other_editions(oclcNumber)
         header = {"Accept": "application/json"}
@@ -807,10 +775,6 @@ class MetadataSession(WorldcatSession):
         if not q:
             raise WorldcatSessionError("Argument 'q' is requried to construct query.")
 
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
-
         url = self._url_brief_bib_search()
         header = {"Accept": "application/json"}
         payload = {
@@ -873,10 +837,6 @@ class MetadataSession(WorldcatSession):
             vetted_numbers = verify_oclc_numbers(oclcNumbers)
         except InvalidOclcNumber as exc:
             raise WorldcatSessionError(exc)
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         header = {"Accept": response_format}
         url = self._url_bib_check_oclc_numbers()
@@ -956,10 +916,6 @@ class MetadataSession(WorldcatSession):
             except InvalidOclcNumber:
                 raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
 
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
-
         url = self._url_member_general_holdings()
         header = {"Accept": "application/json"}
         payload = {
@@ -1038,10 +994,6 @@ class MetadataSession(WorldcatSession):
                 oclcNumber = verify_oclc_number(oclcNumber)
             except InvalidOclcNumber:
                 raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
-
-        # make sure access token is still valid and if not request a new one
-        if self.authorization.is_expired():
-            self._get_new_access_token()
 
         url = self._url_member_shared_print_holdings()
         header = {"Accept": "application/json"}

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -398,7 +398,7 @@ class MetadataSession(WorldcatSession):
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
         Returns:
-            `requests.Response` object
+            list of `requests.Response` objects
         """
         responses = []
 
@@ -463,7 +463,7 @@ class MetadataSession(WorldcatSession):
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
         Returns:
-            `requests.Response` object
+            list of `requests.Response` objects
         """
         responses = []
 

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -495,6 +495,25 @@ class MetadataSession(WorldcatSession):
 
         return responses
 
+    def holdings_set_multi_institutions(
+        self, oclcNumber: Union[int, str], instSymbols: str
+    ) -> List[Response]:
+        """
+        Batch sets intitution holdings for multiple intitutions
+
+        Uses /ih/institutionlist endpoint
+
+        Args:
+            oclcNumber:             OCLC bibliographic record number; can be an
+                                    integer, or string with or without OCLC # prefix
+            instSymbols:            a comma-separated list of OCLC symbols of the
+                                    institution whose holdings are being set
+        """
+        try:
+            oclcNumber = verify_oclc_number(oclcNumber)
+        except InvalidOclcNumber:
+            raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+
     def search_brief_bib_other_editions(
         self,
         oclcNumber: Union[int, str],

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -71,7 +71,9 @@ class Query:
                 self.response.raise_for_status()
 
         except HTTPError as exc:
-            raise WorldcatRequestError(f"{exc}")
+            raise WorldcatRequestError(
+                f"{exc}. Server response: {self.response.content}"
+            )
         except (Timeout, ConnectionError):
             raise WorldcatRequestError(f"Connection Error: {sys.exc_info()[0]}")
         except:

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -16,7 +16,7 @@ from .errors import WorldcatRequestError
 
 class Query:
     """
-    Sends a request to OClC service and unifies received excepitons
+    Sends a request to OClC service and unifies received exceptions
 
     `Query.response` attribute is `requests.Response` instance that
     can be parsed to exctract received information from the web service.

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -3,20 +3,25 @@
 """
 Handles actual requests to OCLC services
 """
-from typing import Optional, Union, Tuple
+from __future__ import annotations
+from typing import Optional, Union, Tuple, TYPE_CHECKING
 import sys
 
-from requests import Session
 from requests.models import PreparedRequest
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
-
 from .errors import WorldcatRequestError
+
+
+if TYPE_CHECKING:
+    from .metadata_api import MetadataSession
 
 
 class Query:
     """
     Sends a request to OClC service and unifies received exceptions
+    Query object handles refreshing expired token before request is
+    made to the web service.
 
     `Query.response` attribute is `requests.Response` instance that
     can be parsed to exctract received information from the web service.
@@ -24,7 +29,7 @@ class Query:
 
     def __init__(
         self,
-        session: Session,
+        session: MetadataSession,
         prepared_request: PreparedRequest,
         timeout: Optional[
             Union[int, float, Tuple[int, int], Tuple[float, float]]
@@ -32,7 +37,7 @@ class Query:
     ) -> None:
         """
         Args:
-            session:                        `requests.Session` instance
+            session:                        `metadata_api.MetadataSession` instance
             prepared_request:               `requests.models.PreparedRequest` instance
             timeout:                        how long to wait for server to send data
                                             before giving up
@@ -43,6 +48,10 @@ class Query:
         """
         if not isinstance(prepared_request, PreparedRequest):
             raise AttributeError("Invalid type for argument 'prepared_request'.")
+
+        # make sure access token is still valid and if not request a new one
+        if session.authorization.is_expired():
+            session._get_new_access_token()
 
         self.response = None
 

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -14,7 +14,7 @@ from .errors import WorldcatRequestError
 
 
 if TYPE_CHECKING:
-    from .metadata_api import MetadataSession
+    from .metadata_api import MetadataSession  # pragma: no cover
 
 
 class Query:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.0] - (3/11/2022)
+### Added
++ feature to set and unset holdings for individual record for multiple institutions (/ih/institutionlist endpoint)
++ `__repr__` method to `WorldcatAccessToken` object
+
+### Changed
++ "refreshing" of access tokens moved to `_session.WorldcatSession` from `metadata_api.MetadataSession` to allow inheritance of this functionality by future clients
++ refactors some of tests
+
 ## [0.4.1] - (2/10/2022) 
 ### Fixed
 + Handling of unexpected 206 HTTP code that is occasionally returned by the MetadataAPI /brief-bibs endpoint

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,13 +37,14 @@ At the moment, the wrapper supports only [OAuth 2.0 endpoints and flows](https:/
     + Set and unset institution holding  (`/ih/data`)
     + Retrieve status of institution holdings (`/ih/checkholdings`)
     + Set and unset institution holdings for a batch or records (`/ih/datalist`)
+    + Set and unset holdings for a single record for multiple intitutions (`/ih/institutionlist`)
 
 
 ## Installation
 
 To install use pip:
 
-`$ pip install bookops-worldcat`
+`$ pip -m install bookops-worldcat`
 
 
 ## Quickstart
@@ -63,8 +64,8 @@ The Worldcat access token can be obtained by passing credential parameters into 
     principal_id="my_principal_id",
     principlal_idns="my_principal_idns"
 )
->>> print(token.token_str)
-"tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW"
+>>> print(token)
+"access_token: 'tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW', expires_at: '2020-01-01 17:19:58Z'"
 >>> print(token.is_expired())
 False
 ```
@@ -429,6 +430,8 @@ session.search_current_control_numbers(oclcNumbers=[12345, 12346, 12347], respon
 + `holding_unset` deletes holding on an individual bibliographic record
 + `holdings_set` allows holdings to be set on multiple records, and is not limited by OCLC's 50 bib record limit
 + `holdings_unset` allows holdings to be deleted on multiple records, and is not limited to OCLC's 50 bib record restriction
++ `holdings_set_multi_institutions` allows to set holdings for a single record for multiple institutions
++ `holdings_unset_multi_institutions` deletes holdings on a single record for multiple institutions
 
 By default, responses are returned in `atom+json` format, but `atom+xml` can be specified:
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -472,6 +472,12 @@ for r in results:
     print(r.json())
 ```
 
+A consortium type of organizations that serve multiple libraries can utilize `holdings_set_multi_institutions` and `holdings_unset_multi_institutions` methods to set and unset holdings for selected libraries. List of library OCLC codes is passed as a comma separated string to instSymbol parameter.
+
+```python
+results = session.holdings_set_multi_institutions(oclcNumber=1234, instSymbols="BKL,NYP")
+```
+
 ## Examples
 
 Complex search query:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bookops-worldcat"
-version = "0.4.1"
+version = "0.5.0"
 description = "OCLC WorldCat Metadata APIs wrapper"
 authors = ["Tomasz Kalata <klingaroo@gmail.com>"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ class MockAuthServerResponseFailure:
 
     def __init__(self):
         self.status_code = 403
+        self.content = b""
 
     def json(self):
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ class MockHTTPSessionResponse(Response):
         self.status_code = http_code
         self.reason = "'foo'"
         self.url = "https://foo.bar?query"
+        self._content = b"spam"
 
 
 @pytest.fixture

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -34,9 +34,7 @@ class TestWorldcatAccessToken:
             ),
         ],
     )
-    def test_key_exceptions(
-        self, argm, expectation, msg, mock_successful_post_token_response
-    ):
+    def test_key_exceptions(self, argm, expectation, msg):
         with expectation as exp:
             WorldcatAccessToken(
                 key=argm,

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -393,7 +393,7 @@ class TestWorldcatAccessToken:
     ):
         assert (
             str(mock_token)
-            == "access_token: 'tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW', token_type: 'bearer', expires_at: '2020-01-01 17:19:58Z'"
+            == "access_token: 'tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW', expires_at: '2020-01-01 17:19:58Z'"
         )
 
     @pytest.mark.webtest

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -113,9 +113,7 @@ class TestWorldcatAccessToken:
             ),
         ],
     )
-    def test_principal_id_exception(
-        self, arg, expectation, msg, mock_successful_post_token_response
-    ):
+    def test_principal_id_exception(self, arg, expectation, msg):
         with expectation as exc:
             WorldcatAccessToken(
                 key="my_key",
@@ -141,9 +139,7 @@ class TestWorldcatAccessToken:
             ),
         ],
     )
-    def test_principal_idns_exception(
-        self, arg, expectation, msg, mock_successful_post_token_response
-    ):
+    def test_principal_idns_exception(self, arg, expectation, msg):
         with expectation as exc:
             WorldcatAccessToken(
                 key="my_key",
@@ -179,9 +175,7 @@ class TestWorldcatAccessToken:
             ),
         ],
     )
-    def test_scope_exceptions(
-        self, argm, expectation, msg, mock_successful_post_token_response
-    ):
+    def test_scope_exceptions(self, argm, expectation, msg):
         with expectation as exp:
             WorldcatAccessToken(
                 key="my_key",
@@ -350,42 +344,23 @@ class TestWorldcatAccessToken:
         )
         assert token.is_expired() is False
 
-    def test_is_expired_true(
-        self, mock_utcnow, mock_credentials, mock_successful_post_token_response
-    ):
-        creds = mock_credentials
-        token = WorldcatAccessToken(
-            key=creds["key"],
-            secret=creds["secret"],
-            scopes=creds["scopes"],
-            principal_id=creds["principal_id"],
-            principal_idns=creds["principal_idns"],
-        )
-        token.token_expires_at = datetime.datetime.strftime(
+    def test_is_expired_true(self, mock_utcnow, mock_token):
+        mock_token.is_expired() is False
+        mock_token.token_expires_at = datetime.datetime.strftime(
             datetime.datetime.utcnow() - datetime.timedelta(0, 1),
             "%Y-%m-%d %H:%M:%SZ",
         )
 
-        assert token.is_expired() is True
+        assert mock_token.is_expired() is True
 
     @pytest.mark.parametrize(
         "arg,expectation",
         [(None, pytest.raises(TypeError)), ("20-01-01", pytest.raises(ValueError))],
     )
-    def test_is_expired_exception(
-        self, arg, expectation, mock_credentials, mock_successful_post_token_response
-    ):
-        creds = mock_credentials
-        token = WorldcatAccessToken(
-            key=creds["key"],
-            secret=creds["secret"],
-            scopes=creds["scopes"],
-            principal_id=creds["principal_id"],
-            principal_idns=creds["principal_idns"],
-        )
-        token.token_expires_at = arg
+    def test_is_expired_exception(self, arg, expectation, mock_token):
+        mock_token.token_expires_at = arg
         with expectation:
-            token.is_expired()
+            mock_token.is_expired()
 
     def test_post_token_request(
         self,

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -415,6 +415,16 @@ class TestWorldcatAccessToken:
         assert token.server_response.json() == mock_oauth_server_response.json()
         assert token.timeout == (3, 3)
 
+    def test_token_repr(
+        self,
+        mock_token,
+        mock_utcnow,
+    ):
+        assert (
+            str(mock_token)
+            == "access_token: 'tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW', token_type: 'bearer', expires_at: '2020-01-01 17:19:58Z'"
+        )
+
     @pytest.mark.webtest
     def test_cred_in_env_variables(self, live_keys):
         assert os.getenv("WCKey") is not None

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -65,9 +65,7 @@ class TestWorldcatAccessToken:
             ),
         ],
     )
-    def test_secret_exceptions(
-        self, argm, expectation, msg, mock_successful_post_token_response
-    ):
+    def test_secret_exceptions(self, argm, expectation, msg):
         with expectation as exp:
             WorldcatAccessToken(
                 key="my_key",
@@ -78,7 +76,7 @@ class TestWorldcatAccessToken:
             )
             assert msg in str(exp.value)
 
-    def test_agent_exceptions(self, mock_successful_post_token_response):
+    def test_agent_exceptions(self):
         with pytest.raises(WorldcatAuthorizationError) as exp:
             WorldcatAccessToken(
                 key="my_key",

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -400,6 +400,82 @@ class TestMockedMetadataSession:
             assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.http_code(200)
+    def test_holdings_set_multi_institutions(self, stub_session, mock_session_response):
+        results = stub_session.holdings_set_multi_institutions(
+            oclcNumber=850940548, instSymbols="BKL,NYP"
+        )
+        assert results.status_code == 200
+
+    def test_holdings_set_multi_institutions_missing_oclc_number(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_set_multi_institutions(instSymbols="NYP,BKL")
+
+    def test_holdings_set_multi_institutions_missing_inst_symbols(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_set_multi_institutions(oclcNumber=123)
+
+    def test_holdings_set_multi_institutions_invalid_oclc_number(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.holdings_set_multi_institutions(
+                oclcNumber="odn1234", instSymbols="NYP,BKL"
+            )
+
+    @pytest.mark.http_code(200)
+    def test_holdings_set_multi_institutions_stale_token(
+        self, mock_utcnow, stub_session, mock_session_response
+    ):
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        with does_not_raise():
+            assert stub_session.authorization.is_expired() is True
+            stub_session.holdings_set_multi_institutions(
+                oclcNumber=850940548, instSymbols="NYP,BKL"
+            )
+            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.is_expired() is False
+
+    @pytest.mark.http_code(200)
+    def test_holdings_unset_multi_institutions(
+        self, stub_session, mock_session_response
+    ):
+        results = stub_session.holdings_unset_multi_institutions(
+            850940548, "BKL,NYP", cascade="1"
+        )
+        assert results.status_code == 200
+
+    def test_holdings_unset_multi_institutions_missing_oclc_number(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_unset_multi_institutions(instSymbols="NYP,BKL")
+
+    def test_holdings_unset_multi_institutions_missing_inst_symbols(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_unset_multi_institutions(oclcNumber=123)
+
+    def test_holdings_unset_multi_institutions_invalid_oclc_number(self, stub_session):
+        with pytest.raises(WorldcatSessionError):
+            stub_session.holdings_unset_multi_institutions(
+                oclcNumber="odn1234", instSymbols="NYP,BKL"
+            )
+
+    @pytest.mark.http_code(200)
+    def test_holdings_unset_multi_institutions_stale_token(
+        self, mock_utcnow, stub_session, mock_session_response
+    ):
+        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
+            "%Y-%m-%d %H:%M:%SZ",
+        )
+        with does_not_raise():
+            assert stub_session.authorization.is_expired() is True
+            stub_session.holdings_unset_multi_institutions(
+                oclcNumber=850940548, instSymbols="NYP,BKL"
+            )
+            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.is_expired() is False
+
+    @pytest.mark.http_code(200)
     def test_search_brief_bibs_other_editions(
         self, stub_session, mock_session_response
     ):

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -222,8 +222,13 @@ class TestMockedMetadataSession:
     def test_get_brief_bib_404_error_response(
         self, stub_session, mock_session_response
     ):
-        with pytest.raises(WorldcatRequestError):
+        with pytest.raises(WorldcatRequestError) as exc:
             stub_session.get_brief_bib(12345)
+
+        assert (
+            "404 Client Error: 'foo' for url: https://foo.bar?query. Server response: b'spam'"
+            in (str(exc.value))
+        )
 
     @pytest.mark.http_code(200)
     def test_get_full_bib(self, stub_session, mock_session_response):
@@ -435,6 +440,20 @@ class TestMockedMetadataSession:
             )
             assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
             assert stub_session.authorization.is_expired() is False
+
+    @pytest.mark.http_code(403)
+    def test_holdings_set_multi_institutions_permission_error(
+        self, stub_session, mock_session_response
+    ):
+        with pytest.raises(WorldcatRequestError) as exc:
+            stub_session.holdings_set_multi_institutions(
+                oclcNumber=850940548, instSymbols="NYP,BKL"
+            )
+
+        assert (
+            "403 Client Error: 'foo' for url: https://foo.bar?query. Server response: b'spam'"
+            in str(exc.value)
+        )
 
     @pytest.mark.http_code(200)
     def test_holdings_unset_multi_institutions(

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 import datetime
 import os
+from types import GeneratorType
 
 import pytest
 
@@ -34,7 +35,7 @@ class TestMockedMetadataSession:
             MetadataSession()
 
     def test_invalid_authorizaiton(self):
-        err_msg = "Argument 'authorization' must include 'WorldcatAccessToken' object."
+        err_msg = "Argument 'authorization' must be 'WorldcatAccessToken' object."
         with pytest.raises(WorldcatSessionError) as exc:
             MetadataSession(authorization="my_token")
         assert err_msg in str(exc.value)
@@ -56,25 +57,25 @@ class TestMockedMetadataSession:
             stub_session._get_new_access_token()
 
     @pytest.mark.parametrize(
-        "oclcNumbers,buckets,expectation",
+        "oclcNumbers,expectation",
         [
-            ([], 0, []),
-            (["1", "2", "3"], 1, ["1,2,3"]),
-            ([1, 2, 3], 1, ["1,2,3"]),
-            (["1"], 1, ["1"]),
-            (["1"] * 50, 1, [",".join(["1"] * 50)]),
-            (["1"] * 51, 2, [",".join(["1"] * 50), "1"]),
-            (
+            pytest.param([], [], id="empty list"),
+            pytest.param(["1", "2", "3"], ["1,2,3"], id="list of str"),
+            pytest.param(["1"], ["1"], id="list of one"),
+            pytest.param(["1"] * 50, [",".join(["1"] * 50)], id="full batch"),
+            pytest.param(["1"] * 51, [",".join(["1"] * 50), "1"], id="2 batches"),
+            pytest.param(
                 ["1"] * 103,
-                3,
                 [",".join(["1"] * 50), ",".join(["1"] * 50), "1,1,1"],
+                id="3 batches",
             ),
         ],
     )
-    def test_split_into_legal_volume(
-        self, stub_session, oclcNumbers, buckets, expectation
-    ):
-        assert stub_session._split_into_legal_volume(oclcNumbers) == expectation
+    def test_split_into_legal_volume(self, stub_session, oclcNumbers, expectation):
+        batches = stub_session._split_into_legal_volume(oclcNumbers)
+        assert isinstance(batches, GeneratorType)
+        all_batches = [b for b in batches]
+        assert all_batches == expectation
 
     def test_url_base(self, stub_session):
         assert stub_session._url_base() == "https://worldcat.org"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,11 +11,17 @@ from bookops_worldcat.errors import WorldcatSessionError
 class TestWorldcatSession:
     """Test the base WorldcatSession"""
 
-    def test_default_user_agent_header(self):
-        assert WorldcatSession().headers["User-Agent"] == f"{__title__}/{__version__}"
+    def test_default_user_agent_header(self, mock_token):
+        assert (
+            WorldcatSession(mock_token).headers["User-Agent"]
+            == f"{__title__}/{__version__}"
+        )
 
-    def test_custom_user_agent_header(self):
-        assert WorldcatSession(agent="my_app").headers["User-Agent"] == "my_app"
+    def test_custom_user_agent_header(self, mock_token):
+        assert (
+            WorldcatSession(mock_token, agent="my_app").headers["User-Agent"]
+            == "my_app"
+        )
 
     @pytest.mark.parametrize(
         "argm,expectation",
@@ -25,15 +31,15 @@ class TestWorldcatSession:
             ((), pytest.raises(WorldcatSessionError)),
         ],
     )
-    def test_invalid_user_agent_arguments(self, argm, expectation):
+    def test_invalid_user_agent_arguments(self, argm, expectation, mock_token):
         with expectation:
-            WorldcatSession(agent=argm)
+            WorldcatSession(mock_token, agent=argm)
             assert "Argument 'agent' must be a str" in str(expectation.value)
 
-    def test_default_timeout(self):
-        with WorldcatSession(timeout=None) as session:
+    def test_default_timeout(self, mock_token):
+        with WorldcatSession(mock_token, timeout=None) as session:
             assert session.timeout == (5, 5)
 
-    def test_custom_timeout(self):
-        with WorldcatSession(timeout=1) as session:
+    def test_custom_timeout(self, mock_token):
+        with WorldcatSession(mock_token, timeout=1) as session:
             assert session.timeout == 1

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,7 +10,7 @@ from bookops_worldcat.__version__ import (
 
 
 def test_version():
-    assert __version__ == "0.4.1"
+    assert __version__ == "0.5.0"
 
 
 def test_title():


### PR DESCRIPTION
### Adds:
+ set and unset OCLC holdings for multiple institutions (for consortia): /ih/institutionlist endpoint
+ `__repr__` method to `WorldcatAccessToken` class
+ fuller response when `WorldcatRequestError` is raised that provides details returned by the service

### Fixes:
+ authentication server response when request to obtain an access token fails

### Changed:
+ test fixtures refactoring
