### PR TITLE
Authentication updates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores =
+    tests/*:E501

--- a/poetry.lock
+++ b/poetry.lock
@@ -743,6 +743,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -833,6 +834,20 @@ files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.20240125"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-requests-2.31.0.20240125.tar.gz", hash = "sha256:03a28ce1d7cd54199148e043b2079cdded22d6795d19a2c2a6791a4b2b5e2eb5"},
+    {file = "types_requests-2.31.0.20240125-py3-none-any.whl", hash = "sha256:9592a9a4cb92d6d75d9b491a41477272b710e021011a2a3061157e2fb1f1a5d1"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
 
 [[package]]
 name = "typing-extensions"
@@ -933,4 +948,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0a1e9f10d76b700432f2918602f86c38e5d08d64ebeee9f9c24f1df4795bc680"
+content-hash = "44dd5d9a628e03eb12251465385f8d287b8f1d91d6c1f6cfc7f6c708282802c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ mypy = "^1.8"
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/BookOps-CAT/bookops-worldcat/issues"
 
+[tool.poetry.group.dev.dependencies]
+types-requests = "^2.31.0.20240125"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ classifiers = [
 python = "^3.8"
 requests = "^2.31"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.urls]
+"Bug Tracker" = "https://github.com/BookOps-CAT/bookops-worldcat/issues"
+
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 pytest-cov = "^3.0"
 pytest-mock = "^3.7"
@@ -41,11 +44,6 @@ black = "^23.3.0"
 mike = "^2.0.0"
 mkapi = "^1.0.14"
 mypy = "^1.8"
-
-[tool.poetry.urls]
-"Bug Tracker" = "https://github.com/BookOps-CAT/bookops-worldcat/issues"
-
-[tool.poetry.group.dev.dependencies]
 types-requests = "^2.31.0.20240125"
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def mock_credentials():
     return {
         "key": "my_WSkey",
         "secret": "my_WSsecret",
-        "scopes": ["scope1", "scope2"],
+        "scopes": "scope1 scope2",
         "principal_id": "my_principalID",
         "principal_idns": "my_principalIDNS",
     }

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import datetime
-from contextlib import nullcontext as does_not_raise
 import os
 
 import pytest
@@ -264,7 +263,9 @@ class TestWorldcatAccessToken:
     def test_hasten_expiration_time(self, mock_token):
         utc_stamp = "2020-01-01 17:19:59Z"
         token = mock_token
-        assert token._hasten_expiration_time(utc_stamp) == "2020-01-01 17:19:58Z"
+        timestamp = token._hasten_expiration_time(utc_stamp)
+        assert isinstance(timestamp, datetime.datetime)
+        assert timestamp == datetime.datetime(2020, 1, 1, 17, 19, 58, 0)
 
     def test_payload(self, mock_successful_post_token_response):
         token = WorldcatAccessToken(
@@ -347,16 +348,15 @@ class TestWorldcatAccessToken:
 
     def test_is_expired_true(self, mock_utcnow, mock_token):
         mock_token.is_expired() is False
-        mock_token.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        mock_token.token_expires_at = datetime.datetime.utcnow() - datetime.timedelta(
+            0, 1
         )
 
         assert mock_token.is_expired() is True
 
     @pytest.mark.parametrize(
         "arg,expectation",
-        [(None, pytest.raises(TypeError)), ("20-01-01", pytest.raises(ValueError))],
+        [(None, pytest.raises(TypeError))],
     )
     def test_is_expired_exception(self, arg, expectation, mock_token):
         mock_token.token_expires_at = arg
@@ -439,5 +439,4 @@ class TestWorldcatAccessToken:
         # test if token looks right
         assert token.token_str.startswith("tk_")
         assert token.is_expired() is False
-        with does_not_raise():
-            datetime.datetime.strptime(token.token_expires_at, "%Y-%m-%d %H:%M:%SZ")
+        assert isinstance(token.token_expires_at, datetime.datetime)

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+from contextlib import nullcontext as does_not_raise
 import os
 
 import pytest
@@ -156,22 +157,22 @@ class TestWorldcatAccessToken:
             (
                 None,
                 pytest.raises(WorldcatAuthorizationError),
-                "Argument 'scope' must a string or a list.",
+                "Argument 'scopes' must a string.",
             ),
             (
                 123,
                 pytest.raises(WorldcatAuthorizationError),
-                "Argument 'scope' must a string or a list.",
+                "Argument 'scopes' must a string.",
             ),
             (
                 " ",
                 pytest.raises(WorldcatAuthorizationError),
-                "Argument 'scope' is missing.",
+                "Argument 'scopes' is required.",
             ),
             (
                 ["", ""],
                 pytest.raises(WorldcatAuthorizationError),
-                "Argument 'scope' is missing.",
+                "Argument 'scopes' is required.",
             ),
         ],
     )
@@ -211,7 +212,7 @@ class TestWorldcatAccessToken:
 
     @pytest.mark.parametrize(
         "argm,expectation",
-        [("scope1", "scope1"), (["scope1", "scope2"], "scope1 scope2")],
+        [("scope1 ", "scope1"), (" scope1 scope2 ", "scope1 scope2")],
     )
     def test_scope_manipulation(
         self, argm, expectation, mock_successful_post_token_response
@@ -436,5 +437,7 @@ class TestWorldcatAccessToken:
         assert sorted(params) == sorted(response.keys())
 
         # test if token looks right
-        assert token.token_str is not None
+        assert token.token_str.startswith("tk_")
         assert token.is_expired() is False
+        with does_not_raise():
+            datetime.datetime.strptime(token.token_expires_at, "%Y-%m-%d %H:%M:%SZ")

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -43,13 +43,14 @@ class TestMockedMetadataSession:
     def test_get_new_access_token(self, mock_token, mock_utcnow):
         assert mock_token.is_expired() is False
         with MetadataSession(authorization=mock_token) as session:
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
+            session.authorization.token_expires_at = (
+                datetime.datetime.utcnow() - datetime.timedelta(0, 1)
             )
             assert session.authorization.is_expired() is True
             session._get_new_access_token()
-            assert session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert session.authorization.token_expires_at == datetime.datetime(
+                2020, 1, 1, 17, 19, 58
+            )
             assert session.authorization.is_expired() is False
 
     def test_get_new_access_token_exceptions(self, stub_session, mock_timeout):
@@ -202,13 +203,14 @@ class TestMockedMetadataSession:
     def test_get_brief_bib_with_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.get_brief_bib(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -244,14 +246,16 @@ class TestMockedMetadataSession:
 
     @pytest.mark.http_code(200)
     def test_get_full_bib_with_stale_token(self, stub_session, mock_session_response):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
+
         assert stub_session.authorization.is_expired() is True
         response = stub_session.get_full_bib(12345)
         assert stub_session.authorization.is_expired() is False
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert response.status_code == 200
 
     @pytest.mark.http_code(200)
@@ -270,14 +274,15 @@ class TestMockedMetadataSession:
     def test_holding_get_status_with_stale_token(
         self, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.holding_get_status(12345)
         assert stub_session.authorization.is_expired() is False
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert response.status_code == 200
 
     @pytest.mark.http_code(201)
@@ -294,13 +299,14 @@ class TestMockedMetadataSession:
 
     @pytest.mark.http_code(201)
     def test_holding_set_stale_token(self, stub_session, mock_session_response):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.holding_set(850940548)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 201
 
@@ -320,13 +326,14 @@ class TestMockedMetadataSession:
     def test_holding_unset_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.holding_unset(850940548)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -356,14 +363,15 @@ class TestMockedMetadataSession:
     def test_holdings_set_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         with does_not_raise():
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_set([850940548, 850940552, 850940554])
-            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.token_expires_at == datetime.datetime(
+                2020, 1, 1, 17, 19, 58
+            )
             assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.parametrize(
@@ -394,14 +402,15 @@ class TestMockedMetadataSession:
     def test_holdings_unset_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         with does_not_raise():
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_unset([850940548, 850940552, 850940554])
-            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.token_expires_at == datetime.datetime(
+                2020, 1, 1, 17, 19, 58
+            )
             assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.http_code(200)
@@ -429,16 +438,17 @@ class TestMockedMetadataSession:
     def test_holdings_set_multi_institutions_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         with does_not_raise():
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_set_multi_institutions(
                 oclcNumber=850940548, instSymbols="NYP,BKL"
             )
-            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.token_expires_at == datetime.datetime(
+                2020, 1, 1, 17, 19, 58
+            )
             assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.http_code(403)
@@ -482,16 +492,17 @@ class TestMockedMetadataSession:
     def test_holdings_unset_multi_institutions_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         with does_not_raise():
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_unset_multi_institutions(
                 oclcNumber=850940548, instSymbols="NYP,BKL"
             )
-            assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+            assert stub_session.authorization.token_expires_at == datetime.datetime(
+                2020, 1, 1, 17, 19, 58
+            )
             assert stub_session.authorization.is_expired() is False
 
     @pytest.mark.http_code(200)
@@ -504,13 +515,14 @@ class TestMockedMetadataSession:
     def test_search_brief_bibs_other_editions_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_brief_bib_other_editions(12345)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -534,13 +546,14 @@ class TestMockedMetadataSession:
     def test_search_brief_bibs_with_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_brief_bibs(q="ti:foo")
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -575,13 +588,14 @@ class TestMockedMetadataSession:
     def test_search_current_control_numbers_with_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_current_control_numbers(["12345", "65891"])
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 207
 
@@ -605,13 +619,14 @@ class TestMockedMetadataSession:
     def test_search_general_holdings_with_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_general_holdings(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -640,13 +655,14 @@ class TestMockedMetadataSession:
     def test_search_shared_print_holdings_with_stale_token(
         self, mock_utcnow, stub_session, mock_session_response
     ):
-        stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-            datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-            "%Y-%m-%d %H:%M:%SZ",
+        stub_session.authorization.token_expires_at = (
+            datetime.datetime.utcnow() - datetime.timedelta(0, 1)
         )
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_shared_print_holdings(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == "2020-01-01 17:19:58Z"
+        assert stub_session.authorization.token_expires_at == datetime.datetime(
+            2020, 1, 1, 17, 19, 58
+        )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
 
@@ -704,7 +720,7 @@ class TestLiveMetadataSession:
             with pytest.raises(WorldcatRequestError) as exc:
                 session.get_brief_bib(41266045)
 
-            assert err_msg == str(exc.value)
+            assert err_msg in str(exc.value)
 
     def test_get_brief_bib_with_stale_token(self, live_keys):
         token = WorldcatAccessToken(
@@ -716,9 +732,8 @@ class TestLiveMetadataSession:
         )
         with MetadataSession(authorization=token) as session:
             session.authorization.is_expired() is False
-            session.authorization.token_expires_at = datetime.datetime.strftime(
-                datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-                "%Y-%m-%d %H:%M:%SZ",
+            session.authorization.token_expires_at = (
+                datetime.datetime.utcnow() - datetime.timedelta(0, 1)
             )
             assert session.authorization.is_expired() is True
             response = session.get_brief_bib(oclcNumber=41266045)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -46,9 +46,8 @@ def test_query_not_prepared_request(stub_session):
 
 @pytest.mark.http_code(200)
 def test_query_with_stale_token(stub_session, mock_utcnow, mock_session_response):
-    stub_session.authorization.token_expires_at = datetime.datetime.strftime(
-        datetime.datetime.utcnow() - datetime.timedelta(0, 1),
-        "%Y-%m-%d %H:%M:%SZ",
+    stub_session.authorization.token_expires_at = (
+        datetime.datetime.utcnow() - datetime.timedelta(0, 1)
     )
     assert stub_session.authorization.is_expired() is True
 


### PR DESCRIPTION
### Changed:
+ `WorldcatAccessToken`'s 'scopes' argument must be a string for simplicity (previously string or list)
+ typing cleanup
+ `token_expires_at` as a `datetime` object

### Added:
+ `types-requests` dependency to support typing
+ E501 Flake8 error ignored in tests (line length)