### PR TITLE
utc fixes

### DIFF
--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -171,6 +171,9 @@ class WorldcatAccessToken:
             self.token_expires_at = self._hasten_expiration_time(
                 response.json()["expires_at"]
             )
+            self.token_expires_at = self.token_expires_at.replace(
+                tzinfo=datetime.timezone.utc
+            )
             self.token_type = response.json()["token_type"]
         else:
             raise WorldcatAuthorizationError(response.content)

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -161,6 +161,7 @@ class WorldcatAccessToken:
         utcstamp = datetime.datetime.strptime(
             utc_stamp_str, "%Y-%m-%d %H:%M:%SZ"
         ) - datetime.timedelta(seconds=1)
+        utcstamp = utcstamp.replace(tzinfo=datetime.timezone.utc)
         return utcstamp
 
     def _parse_server_response(self, response: requests.Response) -> None:
@@ -170,9 +171,6 @@ class WorldcatAccessToken:
             self.token_str = response.json()["access_token"]
             self.token_expires_at = self._hasten_expiration_time(
                 response.json()["expires_at"]
-            )
-            self.token_expires_at = self.token_expires_at.replace(
-                tzinfo=datetime.timezone.utc
             )
             self.token_type = response.json()["token_type"]
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def live_keys():
 class FakeUtcNow(datetime.datetime):
     @classmethod
     def now(cls, tzinfo=datetime.timezone.utc):
-        return cls(2020, 1, 1, 17, 0, 0, 0)
+        return cls(2020, 1, 1, 17, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 
 @pytest.fixture

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -265,7 +265,9 @@ class TestWorldcatAccessToken:
         token = mock_token
         timestamp = token._hasten_expiration_time(utc_stamp)
         assert isinstance(timestamp, datetime.datetime)
-        assert timestamp == datetime.datetime(2020, 1, 1, 17, 19, 58, 0)
+        assert timestamp == datetime.datetime(
+            2020, 1, 1, 17, 19, 58, 0, tzinfo=datetime.timezone.utc
+        )
 
     def test_payload(self, mock_successful_post_token_response):
         token = WorldcatAccessToken(

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -49,7 +49,7 @@ class TestMockedMetadataSession:
             assert session.authorization.is_expired() is True
             session._get_new_access_token()
             assert session.authorization.token_expires_at == datetime.datetime(
-                2020, 1, 1, 17, 19, 58
+                2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
             )
             assert session.authorization.is_expired() is False
 
@@ -209,7 +209,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.get_brief_bib(oclcNumber=12345)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
@@ -254,7 +254,7 @@ class TestMockedMetadataSession:
         response = stub_session.get_full_bib(12345)
         assert stub_session.authorization.is_expired() is False
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert response.status_code == 200
 
@@ -281,7 +281,7 @@ class TestMockedMetadataSession:
         response = stub_session.holding_get_status(12345)
         assert stub_session.authorization.is_expired() is False
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert response.status_code == 200
 
@@ -305,7 +305,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.holding_set(850940548)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 201
@@ -332,7 +332,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.holding_unset(850940548)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
@@ -370,7 +370,7 @@ class TestMockedMetadataSession:
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_set([850940548, 850940552, 850940554])
             assert stub_session.authorization.token_expires_at == datetime.datetime(
-                2020, 1, 1, 17, 19, 58
+                2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
             )
             assert stub_session.authorization.is_expired() is False
 
@@ -409,7 +409,7 @@ class TestMockedMetadataSession:
             assert stub_session.authorization.is_expired() is True
             stub_session.holdings_unset([850940548, 850940552, 850940554])
             assert stub_session.authorization.token_expires_at == datetime.datetime(
-                2020, 1, 1, 17, 19, 58
+                2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
             )
             assert stub_session.authorization.is_expired() is False
 
@@ -447,7 +447,7 @@ class TestMockedMetadataSession:
                 oclcNumber=850940548, instSymbols="NYP,BKL"
             )
             assert stub_session.authorization.token_expires_at == datetime.datetime(
-                2020, 1, 1, 17, 19, 58
+                2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
             )
             assert stub_session.authorization.is_expired() is False
 
@@ -501,7 +501,7 @@ class TestMockedMetadataSession:
                 oclcNumber=850940548, instSymbols="NYP,BKL"
             )
             assert stub_session.authorization.token_expires_at == datetime.datetime(
-                2020, 1, 1, 17, 19, 58
+                2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
             )
             assert stub_session.authorization.is_expired() is False
 
@@ -521,7 +521,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_brief_bib_other_editions(12345)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
@@ -552,7 +552,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_brief_bibs(q="ti:foo")
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
@@ -594,7 +594,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_current_control_numbers(["12345", "65891"])
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 207
@@ -625,7 +625,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_general_holdings(oclcNumber=12345)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200
@@ -661,7 +661,7 @@ class TestMockedMetadataSession:
         assert stub_session.authorization.is_expired() is True
         response = stub_session.search_shared_print_holdings(oclcNumber=12345)
         assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58
+            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
         )
         assert stub_session.authorization.is_expired() is False
         assert response.status_code == 200


### PR DESCRIPTION
changed _hasten_expiration_time() to add timezone.utc to expiration time in response to token request