### PR TITLE
Errors-refactor

### DIFF
--- a/bookops_worldcat/__init__.py
+++ b/bookops_worldcat/__init__.py
@@ -1,4 +1,4 @@
-from .__version__ import __title__, __version__
+from .__version__ import __title__, __version__  # noqa: F401
 
-from .authorize import WorldcatAccessToken
-from .metadata_api import MetadataSession
+from .authorize import WorldcatAccessToken  # noqa: F401
+from .metadata_api import MetadataSession  # noqa: F401

--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -11,7 +11,7 @@ import requests
 
 from . import __title__, __version__
 from .authorize import WorldcatAccessToken
-from .errors import WorldcatSessionError, WorldcatAuthorizationError
+from .errors import WorldcatAuthorizationError
 
 
 class WorldcatSession(requests.Session):
@@ -39,7 +39,7 @@ class WorldcatSession(requests.Session):
         self.authorization = authorization
 
         if not isinstance(self.authorization, WorldcatAccessToken):
-            raise WorldcatSessionError(
+            raise TypeError(
                 "Argument 'authorization' must be 'WorldcatAccessToken' object."
             )
 
@@ -48,7 +48,7 @@ class WorldcatSession(requests.Session):
         elif agent and isinstance(agent, str):
             self.headers.update({"User-Agent": agent})
         else:
-            raise WorldcatSessionError("Argument 'agent' must be a string.")
+            raise ValueError("Argument 'agent' must be a string.")
 
         self.timeout = timeout
 
@@ -59,11 +59,8 @@ class WorldcatSession(requests.Session):
         Allows to continue sending request with new access token after
         the previous one expired
         """
-        try:
-            self.authorization._request_token()
-            self._update_authorization()
-        except WorldcatAuthorizationError as exc:
-            raise WorldcatSessionError(exc)
+        self.authorization._request_token()
+        self._update_authorization()
 
     def _update_authorization(self) -> None:
         self.headers.update({"Authorization": f"Bearer {self.authorization.token_str}"})

--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -11,7 +11,6 @@ import requests
 
 from . import __title__, __version__
 from .authorize import WorldcatAccessToken
-from .errors import WorldcatAuthorizationError
 
 
 class WorldcatSession(requests.Session):

--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -20,7 +20,7 @@ class WorldcatSession(requests.Session):
         self,
         authorization: WorldcatAccessToken,
         agent: Optional[str] = None,
-        timeout: Union[int, float, Tuple[int, int], Tuple[float, float]] = (
+        timeout: Union[int, float, Tuple[int, int], Tuple[float, float], None] = (
             5,
             5,
         ),

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -99,41 +99,43 @@ class WorldcatAccessToken:
         self.token_type = ""
 
         # default bookops-worldcat request header
-        if not self.agent:
-            self.agent = f"{__title__}/{__version__}"
+        if isinstance(self.agent, str):
+            if not self.agent.strip():
+                self.agent = f"{__title__}/{__version__}"
         else:
-            if not isinstance(self.agent, str):
-                raise WorldcatAuthorizationError("Argument 'agent' must be a string.")
+            raise TypeError("Argument 'agent' must be a string.")
 
         # asure passed arguments are valid
-        if not self.key:
-            raise WorldcatAuthorizationError("Argument 'key' is required.")
+        if isinstance(self.key, str):
+            if not self.key.strip():
+                raise ValueError("Argument 'key' cannot be an empty string.")
         else:
-            if not isinstance(self.key, str):
-                raise WorldcatAuthorizationError("Argument 'key' must be a string.")
+            raise TypeError("Argument 'key' must be a string.")
 
-        if not self.secret:
-            raise WorldcatAuthorizationError("Argument 'secret' is required.")
+        if isinstance(self.secret, str):
+            if not self.secret.strip():
+                raise ValueError("Argument 'secret' cannot be an empty string.")
         else:
-            if not isinstance(self.secret, str):
-                raise WorldcatAuthorizationError("Argument 'secret' must be a string.")
+            raise TypeError("Argument 'secret' must be a string.")
 
-        if not self.principal_id:
-            raise WorldcatAuthorizationError(
-                "Argument 'principal_id' is required for read/write endpoint of "
-                "Metadata API."
-            )
-        if not self.principal_idns:
-            raise WorldcatAuthorizationError(
-                "Argument 'principal_idns' is required for read/write endpoint of "
-                "Metadata API."
-            )
+        if isinstance(self.principal_id, str):
+            if not self.principal_id.strip():
+                raise ValueError("Argument 'principal_id' cannot be an empty string.")
+        else:
+            raise TypeError("Argument 'principal_id' must be a string.")
+
+        if isinstance(self.principal_idns, str):
+            if not self.principal_idns.strip():
+                raise ValueError("Argument 'principal_idns' cannot be an empty string.")
+        else:
+            raise TypeError("Argument 'principal_idns' must be a string.")
 
         # validate passed scopes
-        if not self.scopes:
-            raise WorldcatAuthorizationError("Argument 'scopes' is required.")
-        elif not isinstance(self.scopes, str):
-            raise WorldcatAuthorizationError("Argument 'scopes' must a string.")
+        if isinstance(self.scopes, str):
+            if not self.scopes.strip():
+                raise ValueError("Argument 'scopes' cannot be an empty string.")
+        else:
+            raise TypeError("Argument 'scopes' must a string.")
         self.scopes = self.scopes.strip()
 
         # assign default value for timout

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional, Tuple, Union
 import requests
 
 from . import __title__, __version__
-from .errors import WorldcatAuthorizationError, WorldcatRequestError
+from .errors import WorldcatAuthorizationError
 
 
 class WorldcatAccessToken:

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional, Tuple, Union
 import requests
 
 from . import __title__, __version__
-from .errors import WorldcatAuthorizationError
+from .errors import WorldcatAuthorizationError, WorldcatRequestError
 
 
 class WorldcatAccessToken:
@@ -242,7 +242,10 @@ class WorldcatAccessToken:
             else:
                 return False
         else:
-            raise TypeError
+            raise TypeError(
+                "Attribue 'WorldcatAccessToken.token_expires_at' is of invalid type. "
+                "Expected `datetime.datetime` object."
+            )
 
     def __repr__(self):
         return (

--- a/bookops_worldcat/errors.py
+++ b/bookops_worldcat/errors.py
@@ -19,15 +19,7 @@ class WorldcatAuthorizationError(BookopsWorldcatError):
     pass
 
 
-class WorldcatSessionError(BookopsWorldcatError):
-    """
-    Exception raised during WorlCat session
-    """
-
-    pass
-
-
-class WorldcatRequestError(WorldcatSessionError):
+class WorldcatRequestError(BookopsWorldcatError):
     """
     Exceptions raised on HTTP errors returned by web service
     """

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -10,10 +10,7 @@ from requests import Request, Response
 
 from ._session import WorldcatSession
 from .authorize import WorldcatAccessToken
-from .errors import (
-    WorldcatSessionError,
-    InvalidOclcNumber,
-)
+from .errors import InvalidOclcNumber
 from .query import Query
 from .utils import verify_oclc_number, verify_oclc_numbers
 
@@ -139,11 +136,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` instance
         """
-
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber:
-            raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         header = {"Accept": "application/json"}
         url = self._url_brief_bib_oclc_number(oclcNumber)
@@ -177,10 +170,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber:
-            raise WorldcatSessionError("Invalid OCLC # was passed as an argument.")
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_oclc_number(oclcNumber)
         if not response_format:
@@ -228,10 +218,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_holdings_check()
         header = {"Accept": response_format}
@@ -279,11 +266,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_holdings_action()
         header = {"Accept": response_format}
@@ -344,11 +327,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_holdings_action()
         header = {"Accept": response_format}
@@ -401,11 +380,7 @@ class MetadataSession(WorldcatSession):
             list of `requests.Response` objects
         """
         responses = []
-
-        try:
-            vetted_numbers = verify_oclc_numbers(oclcNumbers)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        vetted_numbers = verify_oclc_numbers(oclcNumbers)
 
         url = self._url_bib_holdings_batch_action()
         header = {"Accept": response_format}
@@ -466,11 +441,7 @@ class MetadataSession(WorldcatSession):
             list of `requests.Response` objects
         """
         responses = []
-
-        try:
-            vetted_numbers = verify_oclc_numbers(oclcNumbers)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        vetted_numbers = verify_oclc_numbers(oclcNumbers)
 
         url = self._url_bib_holdings_batch_action()
         header = {"Accept": response_format}
@@ -520,10 +491,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber:
-            raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_holdings_multi_institution_batch_action()
         header = {"Accept": response_format}
@@ -572,10 +540,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber:
-            raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_bib_holdings_multi_institution_batch_action()
         header = {"Accept": response_format}
@@ -699,10 +664,7 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` object
         """
-        try:
-            oclcNumber = verify_oclc_number(oclcNumber)
-        except InvalidOclcNumber:
-            raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+        oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_brief_bib_other_editions(oclcNumber)
         header = {"Accept": "application/json"}
@@ -840,7 +802,7 @@ class MetadataSession(WorldcatSession):
 
         """
         if not q:
-            raise WorldcatSessionError("Argument 'q' is requried to construct query.")
+            raise TypeError("Argument 'q' is requried to construct query.")
 
         url = self._url_brief_bib_search()
         header = {"Accept": "application/json"}
@@ -900,10 +862,7 @@ class MetadataSession(WorldcatSession):
             `requests.Response` object
         """
 
-        try:
-            vetted_numbers = verify_oclc_numbers(oclcNumbers)
-        except InvalidOclcNumber as exc:
-            raise WorldcatSessionError(exc)
+        vetted_numbers = verify_oclc_numbers(oclcNumbers)
 
         header = {"Accept": response_format}
         url = self._url_bib_check_oclc_numbers()
@@ -973,15 +932,12 @@ class MetadataSession(WorldcatSession):
             `requests.Response` object
         """
         if not any([oclcNumber, isbn, issn]):
-            raise WorldcatSessionError(
+            raise TypeError(
                 "Missing required argument. "
                 "One of the following args are required: oclcNumber, issn, isbn"
             )
         if oclcNumber is not None:
-            try:
-                oclcNumber = verify_oclc_number(oclcNumber)
-            except InvalidOclcNumber:
-                raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+            oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_member_general_holdings()
         header = {"Accept": "application/json"}
@@ -1051,16 +1007,13 @@ class MetadataSession(WorldcatSession):
             `requests.Response` object
         """
         if not any([oclcNumber, isbn, issn]):
-            raise WorldcatSessionError(
+            raise TypeError(
                 "Missing required argument. "
                 "One of the following args are required: oclcNumber, issn, isbn"
             )
 
         if oclcNumber is not None:
-            try:
-                oclcNumber = verify_oclc_number(oclcNumber)
-            except InvalidOclcNumber:
-                raise WorldcatSessionError("Invalid OCLC # was passed as an argument")
+            oclcNumber = verify_oclc_number(oclcNumber)
 
         url = self._url_member_shared_print_holdings()
         header = {"Accept": "application/json"}

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -4,13 +4,12 @@
 This module provides MetadataSession class for requests to WorldCat Metadata API.
 """
 
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from requests import Request, Response
 
 from ._session import WorldcatSession
 from .authorize import WorldcatAccessToken
-from .errors import InvalidOclcNumber
 from .query import Query
 from .utils import verify_oclc_number, verify_oclc_numbers
 
@@ -22,9 +21,7 @@ class MetadataSession(WorldcatSession):
         self,
         authorization: WorldcatAccessToken,
         agent: Optional[str] = None,
-        timeout: Optional[
-            Union[int, float, Tuple[int, int], Tuple[float, float]]
-        ] = None,
+        timeout: Union[int, float, Tuple[int, int], Tuple[float, float], None] = None,
     ) -> None:
         """
         Args:
@@ -38,7 +35,7 @@ class MetadataSession(WorldcatSession):
 
     def _split_into_legal_volume(
         self, oclc_numbers: List[str] = [], n: int = 50
-    ) -> List[str]:
+    ) -> Iterator[str]:
         """
         OCLC requries that no more than 50 numbers are passed for batch processing
 
@@ -51,7 +48,7 @@ class MetadataSession(WorldcatSession):
         """
 
         for i in range(0, len(oclc_numbers), n):
-            yield ",".join(oclc_numbers[i : i + n])
+            yield ",".join(oclc_numbers[i : i + n])  # noqa: E203
 
     def _url_base(self) -> str:
         return "https://worldcat.org"
@@ -121,7 +118,7 @@ class MetadataSession(WorldcatSession):
 
     def get_brief_bib(
         self, oclcNumber: Union[int, str], hooks: Optional[Dict[str, Callable]] = None
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Retrieve specific brief bibliographic resource.
         Uses /brief-bibs/{oclcNumber} endpoint.
@@ -155,7 +152,7 @@ class MetadataSession(WorldcatSession):
         oclcNumber: Union[int, str],
         response_format: Optional[str] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Send a GET request for a full bibliographic resource.
         Uses /bib/data/{oclcNumber} endpoint.
@@ -195,7 +192,7 @@ class MetadataSession(WorldcatSession):
         instSymbol: Optional[str] = None,
         response_format: Optional[str] = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Retrieves Worlcat holdings status of a record with provided OCLC number.
         The service automatically recognizes institution based on the issued access
@@ -242,7 +239,7 @@ class MetadataSession(WorldcatSession):
         classificationScheme: Optional[str] = None,
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Sets institution's Worldcat holding on an individual record.
         Uses /ih/data endpoint.
@@ -297,7 +294,7 @@ class MetadataSession(WorldcatSession):
         classificationScheme: Optional[str] = None,
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Deletes institution's Worldcat holding on an individual record.
         Uses /ih/data endpoint.
@@ -356,7 +353,7 @@ class MetadataSession(WorldcatSession):
         instSymbol: Optional[str] = None,
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> List[Response]:
+    ) -> List[Optional[Response]]:
         """
         Set institution holdings for multiple OCLC numbers
         Uses /ih/datalist endpoint.
@@ -412,7 +409,7 @@ class MetadataSession(WorldcatSession):
         instSymbol: Optional[str] = None,
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> List[Response]:
+    ) -> List[Optional[Response]]:
         """
         Set institution holdings for multiple OCLC numbers
         Uses /ih/datalist endpoint.
@@ -472,7 +469,7 @@ class MetadataSession(WorldcatSession):
         instSymbols: str,
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Batch sets intitution holdings for multiple intitutions
 
@@ -516,7 +513,7 @@ class MetadataSession(WorldcatSession):
         cascade: str = "0",
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Batch unsets intitution holdings for multiple intitutions
 
@@ -589,7 +586,7 @@ class MetadataSession(WorldcatSession):
         limit: Optional[int] = None,
         orderBy: Optional[str] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Retrieve other editions related to bibliographic resource with provided
         OCLC #.
@@ -727,7 +724,7 @@ class MetadataSession(WorldcatSession):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Send a GET request for brief bibliographic resources.
         Uses /brief-bibs endpoint.
@@ -842,7 +839,7 @@ class MetadataSession(WorldcatSession):
         oclcNumbers: Union[str, List[Union[str, int]]],
         response_format: str = "application/atom+json",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Retrieve current OCLC control numbers
         Uses /bib/checkcontrolnumbers endpoint.
@@ -879,7 +876,7 @@ class MetadataSession(WorldcatSession):
 
     def search_general_holdings(
         self,
-        oclcNumber: Union[int, str] = None,
+        oclcNumber: Union[int, str, None] = None,
         isbn: Optional[str] = None,
         issn: Optional[str] = None,
         holdingsAllEditions: Optional[bool] = None,
@@ -894,7 +891,7 @@ class MetadataSession(WorldcatSession):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Given a known item gets summary of holdings.
         Uses /bibs-summary-holdings endpoint.
@@ -969,7 +966,7 @@ class MetadataSession(WorldcatSession):
 
     def search_shared_print_holdings(
         self,
-        oclcNumber: Union[int, str] = None,
+        oclcNumber: Union[int, str, None] = None,
         isbn: Optional[str] = None,
         issn: Optional[str] = None,
         heldByGroup: Optional[str] = None,
@@ -979,7 +976,7 @@ class MetadataSession(WorldcatSession):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Response:
+    ) -> Optional[Response]:
         """
         Finds member shared print holdings for specified item.
         Uses /bibs-retained-holdings endpoint.

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -72,7 +72,7 @@ class Query:
 
         except HTTPError as exc:
             raise WorldcatRequestError(
-                f"{exc}. Server response: {self.response.content}"
+                f"{exc}. Server response: {self.response.content.decode('utf-8')}"
             )
         except (Timeout, ConnectionError):
             raise WorldcatRequestError(f"Connection Error: {sys.exc_info()[0]}")

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -47,7 +47,7 @@ class Query:
 
         """
         if not isinstance(prepared_request, PreparedRequest):
-            raise AttributeError("Invalid type for argument 'prepared_request'.")
+            raise TypeError("Invalid type for argument 'prepared_request'.")
 
         # make sure access token is still valid and if not request a new one
         if session.authorization.is_expired():

--- a/bookops_worldcat/query.py
+++ b/bookops_worldcat/query.py
@@ -58,7 +58,7 @@ class Query:
         try:
             self.response = session.send(prepared_request, timeout=timeout)
 
-            if "/ih/data" in prepared_request.url:
+            if "/ih/data" in prepared_request.url:  # type: ignore
                 if self.response.status_code == 409:
                     # HTTP 409 code returns when trying to set/unset
                     # holdings on already set/unset record
@@ -72,7 +72,8 @@ class Query:
 
         except HTTPError as exc:
             raise WorldcatRequestError(
-                f"{exc}. Server response: {self.response.content.decode('utf-8')}"
+                f"{exc}. Server response: "  # type: ignore
+                f"{self.response.content.decode('utf-8')}"
             )
         except (Timeout, ConnectionError):
             raise WorldcatRequestError(f"Connection Error: {sys.exc_info()[0]}")

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -19,17 +19,17 @@ class TestWorldcatAccessToken:
         [
             (
                 None,
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'key' is required.",
+                pytest.raises(TypeError),
+                "Argument 'key' must be a string.",
             ),
             (
                 "",
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'key' is required.",
+                pytest.raises(ValueError),
+                "Argument 'key' cannot be an empty string.",
             ),
             (
                 124,
-                pytest.raises(WorldcatAuthorizationError),
+                pytest.raises(TypeError),
                 "Argument 'key' must be a string.",
             ),
         ],
@@ -43,24 +43,24 @@ class TestWorldcatAccessToken:
                 principal_id="my_principalID",
                 principal_idns="my_principalIDNS",
             )
-            assert msg in str(exp.value)
+        assert msg in str(exp.value)
 
     @pytest.mark.parametrize(
         "argm,expectation,msg",
         [
             (
                 None,
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'secret' is required.",
+                pytest.raises(TypeError),
+                "Argument 'secret' must be a string.",
             ),
             (
                 "",
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'secret' is required.",
+                pytest.raises(ValueError),
+                "Argument 'secret' cannot be an empty string.",
             ),
             (
                 123,
-                pytest.raises(WorldcatAuthorizationError),
+                pytest.raises(TypeError),
                 "Argument 'secret' must be a string.",
             ),
         ],
@@ -74,10 +74,10 @@ class TestWorldcatAccessToken:
                 principal_id="my_principalID",
                 principal_idns="my_principalIDNS",
             )
-            assert msg in str(exp.value)
+        assert msg in str(exp.value)
 
     def test_agent_exceptions(self):
-        with pytest.raises(WorldcatAuthorizationError) as exp:
+        with pytest.raises(TypeError) as exp:
             WorldcatAccessToken(
                 key="my_key",
                 secret="my_secret",
@@ -86,7 +86,7 @@ class TestWorldcatAccessToken:
                 principal_idns="my_principalIDNS",
                 agent=124,
             )
-            assert "Argument 'agent' must be a string." in str(exp.value)
+        assert "Argument 'agent' must be a string." in str(exp.value)
 
     def test_agent_default_values(self, mock_successful_post_token_response):
         token = WorldcatAccessToken(
@@ -103,13 +103,13 @@ class TestWorldcatAccessToken:
         [
             (
                 None,
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'principal_id' is required for read/write endpoint of Metadata API.",
+                pytest.raises(TypeError),
+                "Argument 'principal_id' must be a string.",
             ),
             (
                 "",
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'principal_id' is required for read/write endpoint of Metadata API.",
+                pytest.raises(ValueError),
+                "Argument 'principal_id' cannot be an empty string.",
             ),
         ],
     )
@@ -122,20 +122,20 @@ class TestWorldcatAccessToken:
                 principal_id=arg,
                 principal_idns="my_principalIDNS",
             )
-            assert msg in str(exc.value)
+        assert msg in str(exc.value)
 
     @pytest.mark.parametrize(
         "arg,expectation,msg",
         [
             (
                 None,
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'principal_idns' is required for read/write endpoint of Metadata API.",
+                pytest.raises(TypeError),
+                "Argument 'principal_idns' must be a string.",
             ),
             (
                 "",
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'principal_idns' is required for read/write endpoint of Metadata API.",
+                pytest.raises(ValueError),
+                "Argument 'principal_idns' cannot be an empty string.",
             ),
         ],
     )
@@ -148,29 +148,29 @@ class TestWorldcatAccessToken:
                 principal_id="my_principalID",
                 principal_idns=arg,
             )
-            assert msg in str(exc.value)
+        assert msg in str(exc.value)
 
     @pytest.mark.parametrize(
         "argm,expectation,msg",
         [
             (
                 None,
-                pytest.raises(WorldcatAuthorizationError),
+                pytest.raises(TypeError),
                 "Argument 'scopes' must a string.",
             ),
             (
                 123,
-                pytest.raises(WorldcatAuthorizationError),
+                pytest.raises(TypeError),
                 "Argument 'scopes' must a string.",
             ),
             (
                 " ",
-                pytest.raises(WorldcatAuthorizationError),
-                "Argument 'scopes' is required.",
+                pytest.raises(ValueError),
+                "Argument 'scopes' cannot be an empty string.",
             ),
             (
                 ["", ""],
-                pytest.raises(WorldcatAuthorizationError),
+                pytest.raises(TypeError),
                 "Argument 'scopes' is required.",
             ),
         ],

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -232,7 +232,7 @@ class TestMockedMetadataSession:
             stub_session.get_brief_bib(12345)
 
         assert (
-            "404 Client Error: 'foo' for url: https://foo.bar?query. Server response: b'spam'"
+            "404 Client Error: 'foo' for url: https://foo.bar?query. Server response: spam"
             in (str(exc.value))
         )
 
@@ -465,7 +465,7 @@ class TestMockedMetadataSession:
             )
 
         assert (
-            "403 Client Error: 'foo' for url: https://foo.bar?query. Server response: b'spam'"
+            "403 Client Error: 'foo' for url: https://foo.bar?query. Server response: spam"
             in str(exc.value)
         )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -38,7 +38,7 @@ def test_query_live(live_keys):
 
 
 def test_query_not_prepared_request(stub_session):
-    with pytest.raises(AttributeError) as exc:
+    with pytest.raises(TypeError) as exc:
         req = Request("GET", "https://foo.org")
         Query(stub_session, req, timeout=2)
     assert "Invalid type for argument 'prepared_request'." in str(exc.value)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -106,7 +106,10 @@ def test_query_http_404_response(stub_session, mock_session_response):
     with pytest.raises(WorldcatRequestError) as exc:
         Query(stub_session, prepped)
 
-    assert "404 Client Error: 'foo' for url: https://foo.bar?query" in str(exc.value)
+    assert (
+        "404 Client Error: 'foo' for url: https://foo.bar?query. Server response: spam"
+        in str(exc.value)
+    )
 
 
 @pytest.mark.http_code(500)
@@ -116,7 +119,10 @@ def test_query_http_500_response(stub_session, mock_session_response):
     with pytest.raises(WorldcatRequestError) as exc:
         Query(stub_session, prepped)
 
-    assert "500 Server Error: 'foo' for url: https://foo.bar?query" in str(exc.value)
+    assert (
+        "500 Server Error: 'foo' for url: https://foo.bar?query. Server response: spam"
+        in str(exc.value)
+    )
 
 
 def test_query_timeout_exception(stub_session, mock_timeout):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,7 +5,6 @@ import pytest
 
 from bookops_worldcat._session import WorldcatSession
 from bookops_worldcat.__version__ import __title__, __version__
-from bookops_worldcat.errors import WorldcatSessionError
 
 
 class TestWorldcatSession:
@@ -28,7 +27,7 @@ class TestWorldcatSession:
         [123, {}, (), ""],
     )
     def test_invalid_user_agent_arguments(self, arg, mock_token):
-        with pytest.raises(WorldcatSessionError) as exc:
+        with pytest.raises(ValueError) as exc:
             WorldcatSession(mock_token, agent=arg)
         assert "Argument 'agent' must be a string." in str(exc.value)
 


### PR DESCRIPTION
Drops WorldcatSessionError and replaces other internal exceptions with build-in types: TypeError and ValueError