### PR TITLE
Changed search endpoints

### DIFF
--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -566,7 +566,7 @@ class MetadataSession(WorldcatSession):
         datePublished: Optional[Union[str, List[str]]] = None,
         heldByGroup: Optional[str] = None,
         heldBySymbol: Optional[Union[str, List[str]]] = None,
-        heldByInstitutionID: Optional[Union[str, int, List[str], List[int]]] = None,
+        heldByInstitutionID: Optional[Union[str, int, List[Union[str, int]]]] = None,
         inLanguage: Optional[Union[str, List[str]]] = None,
         inCatalogLanguage: Optional[str] = None,
         materialType: Optional[str] = None,

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -50,31 +50,34 @@ class MetadataSession(WorldcatSession):
         for i in range(0, len(oclc_numbers), n):
             yield ",".join(oclc_numbers[i : i + n])  # noqa: E203
 
+    def URL_BASE(self) -> str:
+        return "https://metadata.api.oclc.org/worldcat"
+
     def _url_base(self) -> str:
         return "https://worldcat.org"
 
     def _url_search_base(self) -> str:
         return "https://americas.metadata.api.oclc.org/worldcat/search/v1"
 
-    def _url_member_shared_print_holdings(self) -> str:
-        base_url = self._url_search_base()
-        return f"{base_url}/bibs-retained-holdings"
+    def _url_search_shared_print_holdings(self) -> str:
+        base_url = self.URL_BASE()
+        return f"{base_url}/search/bibs-retained-holdings"
 
-    def _url_member_general_holdings(self) -> str:
-        base_url = self._url_search_base()
-        return f"{base_url}/bibs-summary-holdings"
+    def _url_search_general_holdings(self) -> str:
+        base_url = self.URL_BASE()
+        return f"{base_url}/search/bibs-summary-holdings"
 
-    def _url_brief_bib_search(self) -> str:
-        base_url = self._url_search_base()
-        return f"{base_url}/brief-bibs"
+    def _url_search_brief_bibs(self) -> str:
+        base_url = self.URL_BASE()
+        return f"{base_url}/search/brief-bibs"
 
-    def _url_brief_bib_oclc_number(self, oclcNumber: str) -> str:
-        base_url = self._url_search_base()
-        return f"{base_url}/brief-bibs/{oclcNumber}"
+    def _url_search_brief_bibs_oclc_number(self, oclcNumber: str) -> str:
+        base_url = self.URL_BASE()
+        return f"{base_url}/search/brief-bibs/{oclcNumber}"
 
-    def _url_brief_bib_other_editions(self, oclcNumber: str) -> str:
-        base_url = self._url_search_base()
-        return f"{base_url}/brief-bibs/{oclcNumber}/other-editions"
+    def _url_search_brief_bibs_other_editions(self, oclcNumber: str) -> str:
+        base_url = self.URL_BASE()
+        return f"{base_url}/search/brief-bibs/{oclcNumber}/other-editions"
 
     def _url_lhr_control_number(self, controlNumber: str) -> str:
         base_url = self._url_search_base()
@@ -121,7 +124,7 @@ class MetadataSession(WorldcatSession):
     ) -> Optional[Response]:
         """
         Retrieve specific brief bibliographic resource.
-        Uses /brief-bibs/{oclcNumber} endpoint.
+        Uses /search/brief-bibs/{oclcNumber} endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be
@@ -135,8 +138,8 @@ class MetadataSession(WorldcatSession):
         """
         oclcNumber = verify_oclc_number(oclcNumber)
 
+        url = self._url_search_brief_bibs_oclc_number(oclcNumber)
         header = {"Accept": "application/json"}
-        url = self._url_brief_bib_oclc_number(oclcNumber)
 
         # prep request
         req = Request("GET", url, headers=header, hooks=hooks)
@@ -556,32 +559,33 @@ class MetadataSession(WorldcatSession):
 
         return query.response
 
-    def search_brief_bib_other_editions(
+    def search_brief_bibs_other_editions(
         self,
         oclcNumber: Union[int, str],
-        deweyNumber: Optional[str] = None,
-        datePublished: Optional[str] = None,
+        deweyNumber: Optional[List[str]] = None,
+        datePublished: Optional[List[str]] = None,
         heldByGroup: Optional[str] = None,
-        heldBySymbol: Optional[str] = None,
-        heldByInstitutionID: Optional[Union[str, int]] = None,
+        heldBySymbol: Optional[List[str]] = None,
+        heldByInstitutionID: Optional[Union[int]] = None,
         inLanguage: Optional[str] = None,
         inCatalogLanguage: Optional[str] = None,
         materialType: Optional[str] = None,
         catalogSource: Optional[str] = None,
-        itemType: Optional[str] = None,
-        itemSubType: Optional[str] = None,
+        itemType: Optional[List[str]] = None,
+        itemSubType: Optional[List[str]] = None,
         retentionCommitments: Optional[bool] = None,
         spProgram: Optional[str] = None,
         genre: Optional[str] = None,
         topic: Optional[str] = None,
         subtopic: Optional[str] = None,
         audience: Optional[str] = None,
-        content: Optional[str] = None,
+        content: Optional[List[str]] = None,
         openAccess: Optional[bool] = None,
         peerReviewed: Optional[bool] = None,
-        facets: Optional[str] = None,
+        facets: Optional[List[str]] = None,
         groupVariantRecords: Optional[bool] = None,
         preferredLanguage: Optional[str] = None,
+        showHoldingsIndicators: Optional[bool] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         orderBy: Optional[str] = None,
@@ -590,71 +594,82 @@ class MetadataSession(WorldcatSession):
         """
         Retrieve other editions related to bibliographic resource with provided
         OCLC #.
-        Uses /brief-bibs/{oclcNumber}/other-editions endpoint.
+        Uses /search/brief-bibs/{oclcNumber}/other-editions endpoint.
 
         Args:
-            oclcNumber:             OCLC bibliographic record number; can be an
-                                    integer, or string with or without OCLC # prefix
+            oclcNumber:             OCLC bibliographic record number; can be
+                                    an integer or string with or without OCLC # prefix
             deweyNumber:            limits the response to the
                                     specified dewey classification number(s);
-                                    for multiple values repeat the parameter,
-                                    example:
+                                    examples:
                                         '794,180'
-            datePublished:          restricts the response to one or
-                                    more dates, or to a range,
+                                        '794'
+            datePublished:          limits the response to one or more dates or ranges
                                     examples:
                                         '2000'
                                         '2000-2005'
                                         '2000,2005'
-            heldByGroup:            restricts to holdings held by group symbol
-            heldBySymbol:           restricts to holdings with specified intitution
-                                    symbol
-            heldByInstitutionID:    restrict to specified institution regisgtryId
-            inLanguage:             restrics the response to the single
+                                        '2000-2002,2003-2005'
+            heldByGroup:            restricts response to holdings held by group symbol
+            heldBySymbol:           restricts response to holdings held by specified
+                                    institution symbol
+            heldByInstitutionID:    restricts response to holdings held by specified
+                                    institution registryId
+            inLanguage:             restricts response to the single
                                     specified language, example: 'fre'
-            inCataloglanguage:      restrics the response to specified
+            inCataloglanguage:      restricts response to specified
                                     cataloging language, example: 'eng';
-                                    default 'eng'
-            materialType:           restricts responses to specified material type,
+                                    default is 'eng'
+            materialType:           restricts response to specified material type,
                                     example: 'bks', 'vis'
-            catalogSource:          restrict to responses to single OCLC symbol as
+            catalogSource:          restricts response to single OCLC symbol as
                                     the cataloging source, example: 'DLC'
             itemType:               restricts reponses to single specified OCLC
                                     top-level facet type, example: 'book'
-            itemSubType:            restricts responses to single specified OCLC
+            itemSubType:            restricts response to single specified OCLC
                                     sub facet type, example: 'digital'
-            retentionCommitments:   restricts responses to bibliographic records
-                                    with retention commitment; True or False,
-                                    default False
-            spProgram:              restricts responses to bibliographic records
+            retentionCommitments:   restricts response to bibliographic records
+                                    with retention commitment; options: True, False,
+                                    default is False
+            spProgram:              restricts response to bibliographic records
                                     associated with particular shared print
                                     program
-            genre:                  genre to limit results to
-            topic:                  topic to limit results to
-            subtopic:               subtopic to limit results to
+            genre:                  genre to limit results to (ge index)
+            topic:                  topic to limit results to (s0 index)
+            subtopic:               subtopic to limit results to (s1 index)
             audience:               audience to limit results to,
-                                    example:
-                                        juv,
-                                        nonJuv
-            content:                content to limit resutls to,
-                                    example:
-                                        fic,
-                                        nonFic,
-                                        fic,bio
-            openAccess:             filter to only open access content, False or True
-            peerReviewed:           filter to only peer reviewed content, False or True
-            facets:                 list of facets to restrict responses
+                                    available values: "juv", 'nonJuv'
+            content:                content to limit results to
+                                    available values: 'fic', 'nonFic', 'bio'
+            openAccess:             restricts response to just open access content
+            peerReviewed:           restricts response to just peer reviewed content
+            facets:                 list of facets requested in response
+                                    available values: 'subject', 'creator',
+                                    'datePublished', 'genre', 'itemType',
+                                    'itemSubTypeBrief', 'itemSubType', 'language',
+                                    'topic', 'subtopic', 'content', 'audience',
+                                    'databases'
             groupVariantRecords:    whether or not to group variant records.
-                                    options: False, True (default False)
+                                    options: True, False, default is False
             preferredLanguage:      language of metadata description,
+                                    default is 'en' (English)
+            showHoldingsIndicators: whether or not to show holdings indicators in
+                                    response. options: True, False, default is False
             offset:                 start position of bibliographic records to
-                                    return; default 1
+                                    return; default is 1
             limit:                  maximum nuber of records to return;
-                                    maximum 50, default 10
-            orderBy:                sort of restuls;
-                                    available values:
-                                        +date, -date, +language, -language;
-                                    default value: -date
+                                    maximum is 50, default is 10
+            orderBy:                results sort key;
+                                    options:
+                                        'library'
+                                        'recency'
+                                        'bestMatch'
+                                        'creator'
+                                        'publicationDateAsc'
+                                        'publicationDateDesc'
+                                        'mostWidelyHeld'
+                                        'title'
+                                    default is bestMatch
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
@@ -663,7 +678,7 @@ class MetadataSession(WorldcatSession):
         """
         oclcNumber = verify_oclc_number(oclcNumber)
 
-        url = self._url_brief_bib_other_editions(oclcNumber)
+        url = self._url_search_brief_bibs_other_editions(oclcNumber)
         header = {"Accept": "application/json"}
         payload = {
             "deweyNumber": deweyNumber,
@@ -673,6 +688,7 @@ class MetadataSession(WorldcatSession):
             "heldByInstitutionID": heldByInstitutionID,
             "inLanguage": inLanguage,
             "inCatalogLanguage": inCatalogLanguage,
+            "materialType": materialType,
             "catalogSource": catalogSource,
             "itemType": itemType,
             "itemSubType": itemSubType,
@@ -688,6 +704,7 @@ class MetadataSession(WorldcatSession):
             "facets": facets,
             "groupVariantRecords": groupVariantRecords,
             "preferredLanguage": preferredLanguage,
+            "showHoldingsIndicators": showHoldingsIndicators,
             "offset": offset,
             "limit": limit,
             "orderBy": orderBy,
@@ -705,21 +722,35 @@ class MetadataSession(WorldcatSession):
     def search_brief_bibs(
         self,
         q: str,
-        deweyNumber: Optional[str] = None,
-        datePublished: Optional[str] = None,
+        deweyNumber: Optional[List[str]] = None,
+        datePublished: Optional[List[str]] = None,
         heldByGroup: Optional[str] = None,
-        inLanguage: Optional[str] = None,
+        heldBySymbol: Optional[List[str]] = None,
+        heldByInstitutionID: Optional[List[int]] = None,
+        inLanguage: Optional[List[str]] = None,
         inCatalogLanguage: Optional[str] = "eng",
         materialType: Optional[str] = None,
         catalogSource: Optional[str] = None,
-        itemType: Optional[str] = None,
-        itemSubType: Optional[str] = None,
+        itemType: Optional[List[str]] = None,
+        itemSubType: Optional[List[str]] = None,
         retentionCommitments: Optional[bool] = None,
         spProgram: Optional[str] = None,
-        facets: Optional[str] = None,
+        genre: Optional[str] = None,
+        topic: Optional[str] = None,
+        subtopic: Optional[str] = None,
+        audience: Optional[str] = None,
+        content: Optional[List[str]] = None,
+        openAccess: Optional[bool] = None,
+        peerReviewed: Optional[bool] = None,
+        facets: Optional[List[str]] = None,
         groupRelatedEditions: Optional[bool] = None,
         groupVariantRecords: Optional[bool] = None,
         preferredLanguage: Optional[str] = None,
+        showHoldingsIndicators: Optional[bool] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        distance: Optional[int] = None,
+        unit: Optional[str] = None,
         orderBy: Optional[str] = "mostWidelyHeld",
         offset: Optional[int] = None,
         limit: Optional[int] = None,
@@ -727,7 +758,7 @@ class MetadataSession(WorldcatSession):
     ) -> Optional[Response]:
         """
         Send a GET request for brief bibliographic resources.
-        Uses /brief-bibs endpoint.
+        Uses /search/brief-bibs endpoint.
 
         Args:
             q:                      query in the form of a keyword search or
@@ -741,73 +772,101 @@ class MetadataSession(WorldcatSession):
                                         (au:Okken OR au:Myers) AND su:python
             deweyNumber:            limits the response to the
                                     specified dewey classification number(s);
-                                    for multiple values repeat the parameter,
-                                    example:
+                                    examples:
                                         '794,180'
-            datePublished:          restricts the response to one or
-                                    more dates, or to a range,
+                                        '794'
+            datePublished:          limits the response to one or more dates or ranges
                                     examples:
                                         '2000'
                                         '2000-2005'
                                         '2000,2005'
-            heldByGroup:            restricts to holdings held by group symbol
-            inLanguage:             restrics the response to the single
+                                        '2000-2002,2003-2005'
+            heldByGroup:            restricts response to holdings held by group symbol
+            heldBySymbol:           restricts response to holdings held by specified
+                                    institution symbol
+            heldByInstitutionID:    restricts response to holdings held by specified
+                                    institution registryId
+            inLanguage:             restricts response to the single
                                     specified language, example: 'fre'
-            inCataloglanguage:      restrics the response to specified
+            inCataloglanguage:      restricts response to specified
                                     cataloging language, example: 'eng';
-                                    default 'eng'
-            materialType:           restricts responses to specified material type,
+                                    default is 'eng'
+            materialType:           restricts response to specified material type,
                                     example: 'bks', 'vis'
-            catalogSource:          restrict to responses to single OCLC symbol as
+            catalogSource:          restricts response to single OCLC symbol as
                                     the cataloging source, example: 'DLC'
             itemType:               restricts reponses to single specified OCLC
                                     top-level facet type, example: 'book'
-            itemSubType:            restricts responses to single specified OCLC
+            itemSubType:            restricts response to single specified OCLC
                                     sub facet type, example: 'digital'
-            retentionCommitments:   restricts responses to bibliographic records
-                                    with retention commitment; True or False
-            spProgram:              restricts responses to bibliographic records
+            retentionCommitments:   restricts response to bibliographic records
+                                    with retention commitment; options: True, False,
+                                    default is False
+            spProgram:              restricts response to bibliographic records
                                     associated with particular shared print
                                     program
-            facets:                 list of facets to restrict responses
+            genre:                  genre to limit results to (ge index)
+            topic:                  topic to limit results to (s0 index)
+            subtopic:               subtopic to limit results to (s1 index)
+            audience:               audience to limit results to,
+                                    available values: 'juv', 'nonJuv'
+            content:                content to limit results to
+                                    available values: 'fic', 'nonFic', 'bio'
+            openAccess:             restricts response to just open access content
+            peerReviewed:           restricts response to just peer reviewed content
+            facets:                 list of facets requested in response
+                                    available values: 'subject', 'creator',
+                                    'datePublished', 'genre', 'itemType',
+                                    'itemSubTypeBrief', 'itemSubType', 'language',
+                                    'topic', 'subtopic', 'content', 'audience',
+                                    'databases'
             groupRelatedEditions:   whether or not use FRBR grouping,
-                                    options: False, True (default is False)
+                                    options: True, False, default is False
             groupVariantRecords:    whether or not to group variant records.
-                                    options: False, True (default False)
+                                    options: True, False, default is False
             preferredLanguage:      language of metadata description,
-                                    default value "en" (English)
+                                    default is 'en' (English)
+            showHoldingsIndicators: whether or not to show holdings indicators in
+                                    response. options: True, False, default is False
+            lat:                    limit to latitude, example: 37.502508
+            lon:                    limit to longitute, example: -122.22702
+            distance:               distance from latitude and longitude
+            unit:                   unit of distance param; options:
+                                    'M' (miles) or 'K' (kilometers)
             orderBy:                results sort key;
                                     options:
+                                        'library'
                                         'recency'
                                         'bestMatch'
                                         'creator'
-                                        'library'
                                         'publicationDateAsc'
                                         'publicationDateDesc'
                                         'mostWidelyHeld'
                                         'title'
+                                    default is bestMatch
             offset:                 start position of bibliographic records to
-                                    return; default 1
-            limit:                  maximum nuber of records to return;
-                                    maximum 50, default 10
+                                    return; default is 1
+            limit:                  maximum number of records to return;
+                                    maximum is 50, default is 10
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
 
         Returns:
             `requests.Response` object
-
         """
         if not q:
             raise TypeError("Argument 'q' is requried to construct query.")
 
-        url = self._url_brief_bib_search()
+        url = self._url_search_brief_bibs()
         header = {"Accept": "application/json"}
         payload = {
             "q": q,
             "deweyNumber": deweyNumber,
             "datePublished": datePublished,
             "heldByGroup": heldByGroup,
+            "heldBySymbol": heldBySymbol,
+            "heldByInstitutionID": heldByInstitutionID,
             "inLanguage": inLanguage,
             "inCatalogLanguage": inCatalogLanguage,
             "materialType": materialType,
@@ -816,10 +875,22 @@ class MetadataSession(WorldcatSession):
             "itemSubType": itemSubType,
             "retentionCommitments": retentionCommitments,
             "spProgram": spProgram,
+            "genre": genre,
+            "topic": topic,
+            "subtopic": subtopic,
+            "audience": audience,
+            "content": content,
+            "openAccess": openAccess,
+            "peerReviewed": peerReviewed,
             "facets": facets,
             "groupRelatedEditions": groupRelatedEditions,
             "groupVariantRecords": groupVariantRecords,
             "preferredLanguage": preferredLanguage,
+            "showHoldingsIndicators": showHoldingsIndicators,
+            "lat": lat,
+            "lon": lon,
+            "distance": distance,
+            "unit": unit,
             "orderBy": orderBy,
             "offset": offset,
             "limit": limit,
@@ -874,54 +945,63 @@ class MetadataSession(WorldcatSession):
 
         return query.response
 
-    def search_general_holdings(
+    def search_bibs_holdings(
         self,
-        oclcNumber: Union[int, str, None] = None,
+        oclcNumber: Optional[Union[int, str]] = None,
         isbn: Optional[str] = None,
         issn: Optional[str] = None,
         holdingsAllEditions: Optional[bool] = None,
         holdingsAllVariantRecords: Optional[bool] = None,
         preferredLanguage: Optional[str] = None,
+        holdingsFilterFormat: Optional[List[str]] = None,
         heldInCountry: Optional[str] = None,
+        heldInState: Optional[str] = None,
         heldByGroup: Optional[str] = None,
+        heldBySymbol: Optional[List[str]] = None,
+        heldByInstitutionID: Optional[List[int]] = None,
+        heldByLibraryType: Optional[List[str]] = None,
         lat: Optional[float] = None,
         lon: Optional[float] = None,
         distance: Optional[int] = None,
         unit: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
-        Given a known item gets summary of holdings.
-        Uses /bibs-summary-holdings endpoint.
+        Given a known item, get summary of holdings and brief bib record.
+        Uses /search/bibs-summary-holdings endpoint.
 
         Args:
             oclcNumber:                 OCLC bibliographic record number; can be
-                                        an integer, or string that can include
-                                        OCLC # prefix
+                                        an integer or string with or without OCLC #
+                                        prefix
             isbn:                       ISBN without any dashes,
                                         example: '978149191646x'
-            issn:                       ISSN (hyphenated, example: '0099-1234')
+            issn:                       ISSN hyphenated, example: '0099-1234'
             holdingsAllEditions:        get holdings for all editions;
-                                        options: True or False
+                                        options: True, False, default is False
             holdingsAllVariantRecords:  get holdings for specific edition across variant
-                                        records; options: False, True
+                                        records; options: True, False, default is False
             preferredLanguage:          language of metadata description;
-                                        default 'en' (English)
-            heldInCountry:              restricts to holdings held by institutions
+                                        default is 'en' (English)
+            holdingsFilterFormat:       get holdings for specific itemSubType,
+                                        example: book-digital
+            heldInCountry:              limits to holdings held by institutions
                                         in requested country
-            heldByGroup:                limits to holdings held by indicated by
-                                        symbol group
+            heldInState:                limits to holdings held by institutions
+                                        in requested state, example: 'US-NY'
+            heldByGroup:                limits to holdings held by institutions
+                                        indicated by group symbol
+            heldBySymbol:               limits to holdings held by institutions
+                                        indicated by institution symbol
+            heldByInstitutionID:        limits to holdings held by institutions
+                                        indicated by institution registryID
+            heldByLibraryType:          limits to holdings held by library type,
+                                        options: 'PUBLIC', 'ALL'
             lat:                        limit to latitude, example: 37.502508
             lon:                        limit to longitute, example: -122.22702
             distance:                   distance from latitude and longitude
             unit:                       unit of distance param; options:
                                         'M' (miles) or 'K' (kilometers)
-            offset:                     start position of bibliographic records to
-                                        return; default 1
-            limit:                      maximum nuber of records to return;
-                                        maximum 50, default 10
             hooks:                      Requests library hook system that can be
                                         used for signal event handling, see more at:
                                         https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
@@ -936,7 +1016,7 @@ class MetadataSession(WorldcatSession):
         if oclcNumber is not None:
             oclcNumber = verify_oclc_number(oclcNumber)
 
-        url = self._url_member_general_holdings()
+        url = self._url_search_general_holdings()
         header = {"Accept": "application/json"}
         payload = {
             "oclcNumber": oclcNumber,
@@ -945,14 +1025,17 @@ class MetadataSession(WorldcatSession):
             "holdingsAllEditions": holdingsAllEditions,
             "holdingsAllVariantRecords": holdingsAllVariantRecords,
             "preferredLanguage": preferredLanguage,
+            "holdingsFilterFormat": holdingsFilterFormat,
             "heldInCountry": heldInCountry,
+            "heldInState": heldInState,
             "heldByGroup": heldByGroup,
+            "heldBySymbol": heldBySymbol,
+            "heldByInstitutionID": heldByInstitutionID,
+            "heldByLibraryType": heldByLibraryType,
             "lat": lat,
             "lon": lon,
             "distance": distance,
             "unit": unit,
-            "offset": offset,
-            "limit": limit,
         }
 
         # prep request
@@ -966,40 +1049,33 @@ class MetadataSession(WorldcatSession):
 
     def search_shared_print_holdings(
         self,
-        oclcNumber: Union[int, str, None] = None,
+        oclcNumber: Optional[Union[int, str]] = None,
         isbn: Optional[str] = None,
         issn: Optional[str] = None,
         heldByGroup: Optional[str] = None,
         heldInState: Optional[str] = None,
-        itemType: Optional[str] = None,
-        itemSubType: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
+        itemType: Optional[List[str]] = None,
+        itemSubType: Optional[List[str]] = None,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
         Finds member shared print holdings for specified item.
-        Uses /bibs-retained-holdings endpoint.
+        Uses /search/bibs-retained-holdings endpoint.
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be
-                                    an integer, or string that can include
-                                    OCLC # prefix
-            isbn:                   ISBN without any dashes,
+                                    an integer or string with or without OCLC # prefix
+            isbn:                   ISBN without hyphen,
                                     example: '978149191646x'
-            issn:                   ISSN (hyphenated, example: '0099-1234')
-            heldByGroup:            restricts to holdings held by group symbol
-            heldInState:            restricts to holings held by institutions
-                                    in requested state, example: "NY"
-            itemType:               restricts results to specified item type (example
-                                    'book' or 'vis')
-            itemSubType:            restricts results to specified item sub type
+            issn:                   ISSN with hyphen, example: '0099-1234'
+            heldByGroup:            limits to holdings held by institutions
+                                    indicated by group symbol
+            heldInState:            limits to holdings held by institutions in
+                                    requested state, example: 'US-NY'
+            itemType:               limits results to specified item type
+                                    examples: 'book' or 'vis'
+            itemSubType:            limits results to specified item sub type
                                     examples: 'book-digital' or 'audiobook-cd'
-            offset:                 start position of bibliographic records to
-                                    return; default 1
-            limit:                  maximum nuber of records to return;
-                                    maximum 50, default 10
-            ""
         Returns:
             `requests.Response` object
         """
@@ -1012,7 +1088,7 @@ class MetadataSession(WorldcatSession):
         if oclcNumber is not None:
             oclcNumber = verify_oclc_number(oclcNumber)
 
-        url = self._url_member_shared_print_holdings()
+        url = self._url_search_shared_print_holdings()
         header = {"Accept": "application/json"}
         payload = {
             "oclcNumber": oclcNumber,
@@ -1020,8 +1096,8 @@ class MetadataSession(WorldcatSession):
             "issn": issn,
             "heldByGroup": heldByGroup,
             "heldInState": heldInState,
-            "offset": offset,
-            "limit": limit,
+            "itemType": itemType,
+            "itemSubType": itemSubType,
         }
 
         # prep request

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -661,8 +661,8 @@ class MetadataSession(WorldcatSession):
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
-            Returns:
-                `requests.Response` object
+        Returns:
+            `requests.Response` object
         """
         oclcNumber = verify_oclc_number(oclcNumber)
 
@@ -832,7 +832,6 @@ class MetadataSession(WorldcatSession):
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
-
         Returns:
             `requests.Response` object
         """

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -562,27 +562,27 @@ class MetadataSession(WorldcatSession):
     def search_brief_bibs_other_editions(
         self,
         oclcNumber: Union[int, str],
-        deweyNumber: Optional[List[str]] = None,
-        datePublished: Optional[List[str]] = None,
+        deweyNumber: Optional[Union[str, List[str]]] = None,
+        datePublished: Optional[Union[str, List[str]]] = None,
         heldByGroup: Optional[str] = None,
-        heldBySymbol: Optional[List[str]] = None,
-        heldByInstitutionID: Optional[Union[int]] = None,
-        inLanguage: Optional[str] = None,
+        heldBySymbol: Optional[Union[str, List[str]]] = None,
+        heldByInstitutionID: Optional[Union[str, int, List[str], List[int]]] = None,
+        inLanguage: Optional[Union[str, List[str]]] = None,
         inCatalogLanguage: Optional[str] = None,
         materialType: Optional[str] = None,
         catalogSource: Optional[str] = None,
-        itemType: Optional[List[str]] = None,
-        itemSubType: Optional[List[str]] = None,
+        itemType: Optional[Union[str, List[str]]] = None,
+        itemSubType: Optional[Union[str, List[str]]] = None,
         retentionCommitments: Optional[bool] = None,
         spProgram: Optional[str] = None,
         genre: Optional[str] = None,
         topic: Optional[str] = None,
         subtopic: Optional[str] = None,
         audience: Optional[str] = None,
-        content: Optional[List[str]] = None,
+        content: Optional[Union[str, List[str]]] = None,
         openAccess: Optional[bool] = None,
         peerReviewed: Optional[bool] = None,
-        facets: Optional[List[str]] = None,
+        facets: Optional[Union[str, List[str]]] = None,
         groupVariantRecords: Optional[bool] = None,
         preferredLanguage: Optional[str] = None,
         showHoldingsIndicators: Optional[bool] = None,
@@ -594,87 +594,75 @@ class MetadataSession(WorldcatSession):
         """
         Retrieve other editions related to bibliographic resource with provided
         OCLC #.
-        Uses /search/brief-bibs/{oclcNumber}/other-editions endpoint.
+        Uses /brief-bibs/{oclcNumber}/other-editions endpoint.
 
         Args:
-            oclcNumber:             OCLC bibliographic record number; can be
-                                    an integer or string with or without OCLC # prefix
+            oclcNumber:             OCLC bibliographic record number; can be an
+                                    integer, or string with or without OCLC # prefix
             deweyNumber:            limits the response to the
-                                    specified dewey classification number(s);
-                                    examples:
+                                    specified dewey classification number(s)
+                                    example:
                                         '794,180'
-                                        '794'
-            datePublished:          limits the response to one or more dates or ranges
+            datePublished:          restricts the response to one or
+                                    more dates, or to a range,
                                     examples:
                                         '2000'
                                         '2000-2005'
                                         '2000,2005'
-                                        '2000-2002,2003-2005'
-            heldByGroup:            restricts response to holdings held by group symbol
-            heldBySymbol:           restricts response to holdings held by specified
-                                    institution symbol
-            heldByInstitutionID:    restricts response to holdings held by specified
-                                    institution registryId
-            inLanguage:             restricts response to the single
+            heldByGroup:            restricts to holdings held by group symbol
+            heldBySymbol:           restricts to holdings with specified intitution
+                                    symbol
+            heldByInstitutionID:    restrict to specified institution regisgtryId
+            inLanguage:             restrics the response to the single
                                     specified language, example: 'fre'
-            inCataloglanguage:      restricts response to specified
+            inCataloglanguage:      restrics the response to specified
                                     cataloging language, example: 'eng';
-                                    default is 'eng'
-            materialType:           restricts response to specified material type,
+                                    default 'eng'
+            materialType:           restricts responses to specified material type,
                                     example: 'bks', 'vis'
-            catalogSource:          restricts response to single OCLC symbol as
+            catalogSource:          restrict to responses to single OCLC symbol as
                                     the cataloging source, example: 'DLC'
             itemType:               restricts reponses to single specified OCLC
                                     top-level facet type, example: 'book'
-            itemSubType:            restricts response to single specified OCLC
+            itemSubType:            restricts responses to single specified OCLC
                                     sub facet type, example: 'digital'
-            retentionCommitments:   restricts response to bibliographic records
-                                    with retention commitment; options: True, False,
-                                    default is False
-            spProgram:              restricts response to bibliographic records
+            retentionCommitments:   restricts responses to bibliographic records
+                                    with retention commitment; True or False,
+                                    default False
+            spProgram:              restricts responses to bibliographic records
                                     associated with particular shared print
                                     program
-            genre:                  genre to limit results to (ge index)
-            topic:                  topic to limit results to (s0 index)
-            subtopic:               subtopic to limit results to (s1 index)
+            genre:                  genre to limit results to
+            topic:                  topic to limit results to
+            subtopic:               subtopic to limit results to
             audience:               audience to limit results to,
-                                    available values: "juv", 'nonJuv'
-            content:                content to limit results to
-                                    available values: 'fic', 'nonFic', 'bio'
-            openAccess:             restricts response to just open access content
-            peerReviewed:           restricts response to just peer reviewed content
-            facets:                 list of facets requested in response
-                                    available values: 'subject', 'creator',
-                                    'datePublished', 'genre', 'itemType',
-                                    'itemSubTypeBrief', 'itemSubType', 'language',
-                                    'topic', 'subtopic', 'content', 'audience',
-                                    'databases'
+                                    example:
+                                        juv,
+                                        nonJuv
+            content:                content to limit resutls to,
+                                    example:
+                                        fic,
+                                        nonFic,
+                                        fic,bio
+            openAccess:             filter to only open access content, False or True
+            peerReviewed:           filter to only peer reviewed content, False or True
+            facets:                 list of facets to restrict responses
             groupVariantRecords:    whether or not to group variant records.
-                                    options: True, False, default is False
+                                    options: False, True (default False)
             preferredLanguage:      language of metadata description,
-                                    default is 'en' (English)
-            showHoldingsIndicators: whether or not to show holdings indicators in
-                                    response. options: True, False, default is False
             offset:                 start position of bibliographic records to
-                                    return; default is 1
+                                    return; default 1
             limit:                  maximum nuber of records to return;
-                                    maximum is 50, default is 10
-            orderBy:                results sort key;
-                                    options:
-                                        'library'
-                                        'recency'
-                                        'bestMatch'
-                                        'creator'
-                                        'publicationDateAsc'
-                                        'publicationDateDesc'
-                                        'mostWidelyHeld'
-                                        'title'
-                                    default is bestMatch
+                                    maximum 50, default 10
+            orderBy:                sort of restuls;
+                                    available values:
+                                        +date, -date, +language, -language;
+                                    default value: -date
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
-        Returns:
-            `requests.Response` object
+            Returns:
+                `requests.Response` object
         """
         oclcNumber = verify_oclc_number(oclcNumber)
 
@@ -722,27 +710,27 @@ class MetadataSession(WorldcatSession):
     def search_brief_bibs(
         self,
         q: str,
-        deweyNumber: Optional[List[str]] = None,
-        datePublished: Optional[List[str]] = None,
+        deweyNumber: Optional[Union[str, List[str]]] = None,
+        datePublished: Optional[Union[str, List[str]]] = None,
         heldByGroup: Optional[str] = None,
-        heldBySymbol: Optional[List[str]] = None,
-        heldByInstitutionID: Optional[List[int]] = None,
-        inLanguage: Optional[List[str]] = None,
-        inCatalogLanguage: Optional[str] = "eng",
+        heldBySymbol: Optional[Union[str, List[str]]] = None,
+        heldByInstitutionID: Optional[Union[str, int, List[str], List[int]]] = None,
+        inLanguage: Optional[Union[str, List[str]]] = None,
+        inCatalogLanguage: Optional[str] = None,
         materialType: Optional[str] = None,
         catalogSource: Optional[str] = None,
-        itemType: Optional[List[str]] = None,
-        itemSubType: Optional[List[str]] = None,
+        itemType: Optional[Union[str, List[str]]] = None,
+        itemSubType: Optional[Union[str, List[str]]] = None,
         retentionCommitments: Optional[bool] = None,
         spProgram: Optional[str] = None,
         genre: Optional[str] = None,
         topic: Optional[str] = None,
         subtopic: Optional[str] = None,
         audience: Optional[str] = None,
-        content: Optional[List[str]] = None,
+        content: Optional[Union[str, List[str]]] = None,
         openAccess: Optional[bool] = None,
         peerReviewed: Optional[bool] = None,
-        facets: Optional[List[str]] = None,
+        facets: Optional[Union[str, List[str]]] = None,
         groupRelatedEditions: Optional[bool] = None,
         groupVariantRecords: Optional[bool] = None,
         preferredLanguage: Optional[str] = None,
@@ -772,37 +760,36 @@ class MetadataSession(WorldcatSession):
                                         (au:Okken OR au:Myers) AND su:python
             deweyNumber:            limits the response to the
                                     specified dewey classification number(s);
-                                    examples:
+                                    for multiple values repeat the parameter,
+                                    example:
                                         '794,180'
-                                        '794'
-            datePublished:          limits the response to one or more dates or ranges
+            datePublished:          restricts the response to one or
+                                    more dates, or to a range,
                                     examples:
                                         '2000'
                                         '2000-2005'
                                         '2000,2005'
-                                        '2000-2002,2003-2005'
-            heldByGroup:            restricts response to holdings held by group symbol
+            heldByGroup:            restricts to holdings held by group symbol
             heldBySymbol:           restricts response to holdings held by specified
                                     institution symbol
             heldByInstitutionID:    restricts response to holdings held by specified
                                     institution registryId
-            inLanguage:             restricts response to the single
+            inLanguage:             restrics the response to the single
                                     specified language, example: 'fre'
-            inCataloglanguage:      restricts response to specified
+            inCataloglanguage:      restrics the response to specified
                                     cataloging language, example: 'eng';
-                                    default is 'eng'
-            materialType:           restricts response to specified material type,
+                                    default 'eng'
+            materialType:           restricts responses to specified material type,
                                     example: 'bks', 'vis'
-            catalogSource:          restricts response to single OCLC symbol as
+            catalogSource:          restrict to responses to single OCLC symbol as
                                     the cataloging source, example: 'DLC'
             itemType:               restricts reponses to single specified OCLC
                                     top-level facet type, example: 'book'
-            itemSubType:            restricts response to single specified OCLC
+            itemSubType:            restricts responses to single specified OCLC
                                     sub facet type, example: 'digital'
-            retentionCommitments:   restricts response to bibliographic records
-                                    with retention commitment; options: True, False,
-                                    default is False
-            spProgram:              restricts response to bibliographic records
+            retentionCommitments:   restricts responses to bibliographic records
+                                    with retention commitment; True or False
+            spProgram:              restricts responses to bibliographic records
                                     associated with particular shared print
                                     program
             genre:                  genre to limit results to (ge index)
@@ -814,18 +801,13 @@ class MetadataSession(WorldcatSession):
                                     available values: 'fic', 'nonFic', 'bio'
             openAccess:             restricts response to just open access content
             peerReviewed:           restricts response to just peer reviewed content
-            facets:                 list of facets requested in response
-                                    available values: 'subject', 'creator',
-                                    'datePublished', 'genre', 'itemType',
-                                    'itemSubTypeBrief', 'itemSubType', 'language',
-                                    'topic', 'subtopic', 'content', 'audience',
-                                    'databases'
+            facets:                 list of facets to restrict responses
             groupRelatedEditions:   whether or not use FRBR grouping,
-                                    options: True, False, default is False
+                                    options: False, True (default is False)
             groupVariantRecords:    whether or not to group variant records.
-                                    options: True, False, default is False
+                                    options: False, True (default False)
             preferredLanguage:      language of metadata description,
-                                    default is 'en' (English)
+                                    default value "en" (English)
             showHoldingsIndicators: whether or not to show holdings indicators in
                                     response. options: True, False, default is False
             lat:                    limit to latitude, example: 37.502508
@@ -835,19 +817,18 @@ class MetadataSession(WorldcatSession):
                                     'M' (miles) or 'K' (kilometers)
             orderBy:                results sort key;
                                     options:
-                                        'library'
                                         'recency'
                                         'bestMatch'
                                         'creator'
+                                        'library'
                                         'publicationDateAsc'
                                         'publicationDateDesc'
                                         'mostWidelyHeld'
                                         'title'
-                                    default is bestMatch
             offset:                 start position of bibliographic records to
-                                    return; default is 1
-            limit:                  maximum number of records to return;
-                                    maximum is 50, default is 10
+                                    return; default 1
+            limit:                  maximum nuber of records to return;
+                                    maximum 50, default 10
             hooks:                  Requests library hook system that can be
                                     used for signal event handling, see more at:
                                     https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
@@ -972,25 +953,25 @@ class MetadataSession(WorldcatSession):
 
         Args:
             oclcNumber:                 OCLC bibliographic record number; can be
-                                        an integer or string with or without OCLC #
-                                        prefix
+                                        an integer, or string that can include
+                                        OCLC # prefix
             isbn:                       ISBN without any dashes,
                                         example: '978149191646x'
-            issn:                       ISSN hyphenated, example: '0099-1234'
+            issn:                       ISSN (hyphenated, example: '0099-1234')
             holdingsAllEditions:        get holdings for all editions;
-                                        options: True, False, default is False
+                                        options: True or False
             holdingsAllVariantRecords:  get holdings for specific edition across variant
-                                        records; options: True, False, default is False
+                                        records; options: False, True
             preferredLanguage:          language of metadata description;
-                                        default is 'en' (English)
+                                        default 'en' (English)
             holdingsFilterFormat:       get holdings for specific itemSubType,
                                         example: book-digital
-            heldInCountry:              limits to holdings held by institutions
+            heldInCountry:              restricts to holdings held by institutions
                                         in requested country
             heldInState:                limits to holdings held by institutions
                                         in requested state, example: 'US-NY'
-            heldByGroup:                limits to holdings held by institutions
-                                        indicated by group symbol
+            heldByGroup:                limits to holdings held by indicated by
+                                        symbol group
             heldBySymbol:               limits to holdings held by institutions
                                         indicated by institution symbol
             heldByInstitutionID:        limits to holdings held by institutions
@@ -1064,18 +1045,21 @@ class MetadataSession(WorldcatSession):
 
         Args:
             oclcNumber:             OCLC bibliographic record number; can be
-                                    an integer or string with or without OCLC # prefix
-            isbn:                   ISBN without hyphen,
+                                    an integer, or string that can include
+                                    OCLC # prefix
+            isbn:                   ISBN without any dashes,
                                     example: '978149191646x'
-            issn:                   ISSN with hyphen, example: '0099-1234'
-            heldByGroup:            limits to holdings held by institutions
-                                    indicated by group symbol
-            heldInState:            limits to holdings held by institutions in
-                                    requested state, example: 'US-NY'
-            itemType:               limits results to specified item type
-                                    examples: 'book' or 'vis'
-            itemSubType:            limits results to specified item sub type
+            issn:                   ISSN (hyphenated, example: '0099-1234')
+            heldByGroup:            restricts to holdings held by group symbol
+            heldInState:            restricts to holings held by institutions
+                                    in requested state, example: "NY"
+            itemType:               restricts results to specified item type (example
+                                    'book' or 'vis')
+            itemSubType:            restricts results to specified item sub type
                                     examples: 'book-digital' or 'audiobook-cd'
+            hooks:                  Requests library hook system that can be used for
+                                    signal event handling, see more at:
+                                    https://requests.readthedocs.io/en/master/user/advanced/#event-hooks
         Returns:
             `requests.Response` object
         """

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -845,7 +845,7 @@ class TestLiveMetadataSession:
                 inLanguage="eng",
                 inCatalogLanguage="eng",
                 itemType="book",
-                itemSubType="book-printbook",
+                itemSubType=["book-printbook", "book-digital"],
                 catalogSource="dlc",
                 orderBy="mostWidelyHeld",
                 limit=5,
@@ -854,7 +854,7 @@ class TestLiveMetadataSession:
             assert sorted(response.json().keys()) == fields
             assert (
                 response.request.url
-                == "https://metadata.api.oclc.org/worldcat/search/brief-bibs?q=ti%3Azendegi+AND+au%3Aegan&inLanguage=eng&inCatalogLanguage=eng&catalogSource=dlc&itemType=book&itemSubType=book-printbook&orderBy=mostWidelyHeld&limit=5"
+                == "https://metadata.api.oclc.org/worldcat/search/brief-bibs?q=ti%3Azendegi+AND+au%3Aegan&inLanguage=eng&inCatalogLanguage=eng&catalogSource=dlc&itemType=book&itemSubType=book-printbook&itemSubType=book-digital&orderBy=mostWidelyHeld&limit=5"
             )
 
     def test_search_bibs_holdings(self, live_keys):

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -82,6 +82,9 @@ class TestMockedMetadataSession:
         all_batches = [b for b in batches]
         assert all_batches == expectation
 
+    def test_new_url_base(self, stub_session):
+        assert stub_session.URL_BASE() == "https://metadata.api.oclc.org/worldcat"
+
     def test_url_base(self, stub_session):
         assert stub_session._url_base() == "https://worldcat.org"
 
@@ -91,47 +94,38 @@ class TestMockedMetadataSession:
             == "https://americas.metadata.api.oclc.org/worldcat/search/v1"
         )
 
-    def test_url_shared_print_holdings(self, stub_session):
+    def test_url_search_shared_print_holdings(self, stub_session):
         assert (
-            stub_session._url_member_shared_print_holdings()
-            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-retained-holdings"
+            stub_session._url_search_shared_print_holdings()
+            == "https://metadata.api.oclc.org/worldcat/search/bibs-retained-holdings"
         )
 
-    def test_url_member_general_holdings(self, stub_session):
+    def test_url_search_general_holdings(self, stub_session):
         assert (
-            stub_session._url_member_general_holdings()
-            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/bibs-summary-holdings"
+            stub_session._url_search_general_holdings()
+            == "https://metadata.api.oclc.org/worldcat/search/bibs-summary-holdings"
         )
 
-    def test_url_brief_bib_search(self, stub_session):
+    def test_url_search_brief_bibs(self, stub_session):
         assert (
-            stub_session._url_brief_bib_search()
-            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs"
+            stub_session._url_search_brief_bibs()
+            == "https://metadata.api.oclc.org/worldcat/search/brief-bibs"
         )
 
     @pytest.mark.parametrize(
-        "argm, expectation",
-        [
-            (
-                "12345",
-                "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345",
-            ),
-            (
-                12345,
-                "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345",
-            ),
-        ],
+        "argm",
+        ["12345", 12345],
     )
-    def test_url_brief_bib_oclc_number(self, argm, expectation, stub_session):
+    def test_url_search_brief_bibs_oclc_number(self, argm, stub_session):
         assert (
-            stub_session._url_brief_bib_oclc_number(oclcNumber=argm)
-            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345"
+            stub_session._url_search_brief_bibs_oclc_number(oclcNumber=argm)
+            == "https://metadata.api.oclc.org/worldcat/search/brief-bibs/12345"
         )
 
-    def test_url_brief_bib_other_editions(self, stub_session):
+    def test_url_search_brief_bibs_other_editions(self, stub_session):
         assert (
-            stub_session._url_brief_bib_other_editions(oclcNumber="12345")
-            == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/12345/other-editions"
+            stub_session._url_search_brief_bibs_other_editions(oclcNumber="12345")
+            == "https://metadata.api.oclc.org/worldcat/search/brief-bibs/12345/other-editions"
         )
 
     def test_url_lhr_control_number(self, stub_session):
@@ -202,21 +196,6 @@ class TestMockedMetadataSession:
     def test_get_brief_bib_None_oclcNumber_passed(self, stub_session):
         with pytest.raises(InvalidOclcNumber):
             stub_session.get_brief_bib(oclcNumber=None)
-
-    @pytest.mark.http_code(200)
-    def test_get_brief_bib_with_stale_token(
-        self, mock_now, stub_session, mock_session_response
-    ):
-        stub_session.authorization.token_expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) - datetime.timedelta(0, 1)
-        assert stub_session.authorization.is_expired() is True
-        response = stub_session.get_brief_bib(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
-        )
-        assert stub_session.authorization.is_expired() is False
-        assert response.status_code == 200
 
     @pytest.mark.http_code(206)
     def test_get_brief_bib_odd_206_http_code(self, stub_session, mock_session_response):
@@ -513,27 +492,12 @@ class TestMockedMetadataSession:
     def test_search_brief_bibs_other_editions(
         self, stub_session, mock_session_response
     ):
-        assert stub_session.search_brief_bib_other_editions(12345).status_code == 200
-
-    @pytest.mark.http_code(200)
-    def test_search_brief_bibs_other_editions_stale_token(
-        self, mock_now, stub_session, mock_session_response
-    ):
-        stub_session.authorization.token_expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) - datetime.timedelta(0, 1)
-        assert stub_session.authorization.is_expired() is True
-        response = stub_session.search_brief_bib_other_editions(12345)
-        assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
-        )
-        assert stub_session.authorization.is_expired() is False
-        assert response.status_code == 200
+        assert stub_session.search_brief_bibs_other_editions(12345).status_code == 200
 
     def test_search_brief_bibs_other_editions_invalid_oclc_number(self, stub_session):
         msg = "Argument 'oclcNumber' does not look like real OCLC #."
         with pytest.raises(InvalidOclcNumber) as exc:
-            stub_session.search_brief_bib_other_editions("odn12345")
+            stub_session.search_brief_bibs_other_editions("odn12345")
         assert msg in str(exc.value)
 
     @pytest.mark.http_code(200)
@@ -545,21 +509,6 @@ class TestMockedMetadataSession:
         with pytest.raises(TypeError) as exc:
             stub_session.search_brief_bibs(argm)
         assert "Argument 'q' is requried to construct query." in str(exc.value)
-
-    @pytest.mark.http_code(200)
-    def test_search_brief_bibs_with_stale_token(
-        self, mock_now, stub_session, mock_session_response
-    ):
-        stub_session.authorization.token_expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) - datetime.timedelta(0, 1)
-        assert stub_session.authorization.is_expired() is True
-        response = stub_session.search_brief_bibs(q="ti:foo")
-        assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
-        )
-        assert stub_session.authorization.is_expired() is False
-        assert response.status_code == 200
 
     @pytest.mark.http_code(207)
     def test_seach_current_control_numbers(self, stub_session, mock_session_response):
@@ -604,35 +553,20 @@ class TestMockedMetadataSession:
         assert response.status_code == 207
 
     @pytest.mark.http_code(200)
-    def test_search_general_holdings(self, stub_session, mock_session_response):
-        assert stub_session.search_general_holdings(oclcNumber=12345).status_code == 200
+    def test_search_bibs_holdings(self, stub_session, mock_session_response):
+        assert stub_session.search_bibs_holdings(oclcNumber=12345).status_code == 200
 
-    def test_search_general_holdings_missing_arguments(self, stub_session):
+    def test_search_bibs_holdings_missing_arguments(self, stub_session):
         msg = "Missing required argument. One of the following args are required: oclcNumber, issn, isbn"
         with pytest.raises(TypeError) as exc:
-            stub_session.search_general_holdings(holdingsAllEditions=True, limit=20)
+            stub_session.search_bibs_holdings(holdingsAllEditions=True)
         assert msg in str(exc.value)
 
-    def test_search_general_holdings_invalid_oclc_number(self, stub_session):
+    def test_search_bibs_holdings_invalid_oclc_number(self, stub_session):
         msg = "Argument 'oclcNumber' does not look like real OCLC #."
         with pytest.raises(InvalidOclcNumber) as exc:
-            stub_session.search_general_holdings(oclcNumber="odn12345")
+            stub_session.search_bibs_holdings(oclcNumber="odn12345")
         assert msg in str(exc.value)
-
-    @pytest.mark.http_code(200)
-    def test_search_general_holdings_with_stale_token(
-        self, mock_now, stub_session, mock_session_response
-    ):
-        stub_session.authorization.token_expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) - datetime.timedelta(0, 1)
-        assert stub_session.authorization.is_expired() is True
-        response = stub_session.search_general_holdings(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
-        )
-        assert stub_session.authorization.is_expired() is False
-        assert response.status_code == 200
 
     @pytest.mark.http_code(200)
     def test_search_shared_print_holdings(self, stub_session, mock_session_response):
@@ -644,7 +578,7 @@ class TestMockedMetadataSession:
     def test_search_shared_print_holdings_missing_arguments(self, stub_session):
         msg = "Missing required argument. One of the following args are required: oclcNumber, issn, isbn"
         with pytest.raises(TypeError) as exc:
-            stub_session.search_shared_print_holdings(heldInState="NY", limit=20)
+            stub_session.search_shared_print_holdings(heldInState="NY")
         assert msg in str(exc.value)
 
     def test_search_shared_print_holdings_with_invalid_oclc_number_passsed(
@@ -654,21 +588,6 @@ class TestMockedMetadataSession:
         with pytest.raises(InvalidOclcNumber) as exc:
             stub_session.search_shared_print_holdings(oclcNumber="odn12345")
         assert msg in str(exc.value)
-
-    @pytest.mark.http_code(200)
-    def test_search_shared_print_holdings_with_stale_token(
-        self, mock_now, stub_session, mock_session_response
-    ):
-        stub_session.authorization.token_expires_at = datetime.datetime.now(
-            datetime.timezone.utc
-        ) - datetime.timedelta(0, 1)
-        assert stub_session.authorization.is_expired() is True
-        response = stub_session.search_shared_print_holdings(oclcNumber=12345)
-        assert stub_session.authorization.token_expires_at == datetime.datetime(
-            2020, 1, 1, 17, 19, 58, tzinfo=datetime.timezone.utc
-        )
-        assert stub_session.authorization.is_expired() is False
-        assert response.status_code == 200
 
 
 @pytest.mark.webtest
@@ -718,31 +637,13 @@ class TestLiveMetadataSession:
             principal_idns=os.getenv("WCPrincipalIDNS"),
         )
         token.token_str = "invalid-token"
-        err_msg = "401 Client Error: Unauthorized for url: https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
+        err_msg = "401 Client Error: Unauthorized for url: https://metadata.api.oclc.org/worldcat/search/brief-bibs/41266045"
         with MetadataSession(authorization=token) as session:
             session.headers.update({"Authorization": "Bearer invalid-token"})
             with pytest.raises(WorldcatRequestError) as exc:
                 session.get_brief_bib(41266045)
 
             assert err_msg in str(exc.value)
-
-    def test_get_brief_bib_with_stale_token(self, live_keys):
-        token = WorldcatAccessToken(
-            key=os.getenv("WCKey"),
-            secret=os.getenv("WCSecret"),
-            scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
-        )
-        with MetadataSession(authorization=token) as session:
-            session.authorization.is_expired() is False
-            session.authorization.token_expires_at = datetime.datetime.now(
-                datetime.timezone.utc
-            ) - datetime.timedelta(0, 1)
-            assert session.authorization.is_expired() is True
-            response = session.get_brief_bib(oclcNumber=41266045)
-            assert session.authorization.is_expired() is False
-            assert response.status_code == 200
 
     def test_get_full_bib(self, live_keys):
         token = WorldcatAccessToken(
@@ -912,7 +813,7 @@ class TestLiveMetadataSession:
                 ]
             )
 
-    def test_brief_bib_other_editions(self, live_keys):
+    def test_brief_bibs_other_editions(self, live_keys):
         fields = sorted(["briefRecords", "numberOfRecords"])
         token = WorldcatAccessToken(
             key=os.getenv("WCKey"),
@@ -923,7 +824,7 @@ class TestLiveMetadataSession:
         )
 
         with MetadataSession(authorization=token) as session:
-            response = session.search_brief_bib_other_editions(41266045)
+            response = session.search_brief_bibs_other_editions(41266045)
 
             assert response.status_code == 200
             assert sorted(response.json().keys()) == fields
@@ -944,20 +845,19 @@ class TestLiveMetadataSession:
                 inLanguage="eng",
                 inCatalogLanguage="eng",
                 itemType="book",
-                # itemSubType="printbook",
+                itemSubType="book-printbook",
                 catalogSource="dlc",
                 orderBy="mostWidelyHeld",
                 limit=5,
             )
             assert response.status_code == 200
             assert sorted(response.json().keys()) == fields
-            # removed temp &itemSubType=printbook due to OCLC error/issue
             assert (
                 response.request.url
-                == "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs?q=ti%3Azendegi+AND+au%3Aegan&inLanguage=eng&inCatalogLanguage=eng&catalogSource=dlc&itemType=book&orderBy=mostWidelyHeld&limit=5"
+                == "https://metadata.api.oclc.org/worldcat/search/brief-bibs?q=ti%3Azendegi+AND+au%3Aegan&inLanguage=eng&inCatalogLanguage=eng&catalogSource=dlc&itemType=book&itemSubType=book-printbook&orderBy=mostWidelyHeld&limit=5"
             )
 
-    def test_search_general_holdings(self, live_keys):
+    def test_search_bibs_holdings(self, live_keys):
         fields = sorted(["briefRecords", "numberOfRecords"])
         token = WorldcatAccessToken(
             key=os.getenv("WCKey"),
@@ -968,7 +868,7 @@ class TestLiveMetadataSession:
         )
 
         with MetadataSession(authorization=token) as session:
-            response = session.search_general_holdings(isbn="9781597801744")
+            response = session.search_bibs_holdings(isbn="9781597801744")
 
             assert response.status_code == 200
             assert sorted(response.json().keys()) == fields


### PR DESCRIPTION
All changes use new base url for Metadata API 2.0
- changed `get_brief_bib`:
  - changed base url
- changed `search_brief_bib_other_editions` to `search_brief_bibs_other_editions`:
  - added `showHoldingsIndicators` as arg
  - changed type hints for multiple args to allow for strings or lists as inputs
- changed `search_brief_bibs`:
  - added multiple args based on changes to endpoint
  - changed type hints for multiple args to allow for strings or lists as inputs
- changed `search_general_holdings` to `search_bibs_holdings`:
  - added multiple args based on changes to endpoint
  - removed `offset` and `limit` as args
- changed `search_shared_print_holdings`:
  - removed `offset` and `limit` as args
  - changed type hints for `itemType` and `itemSubType`
- refactored tests based on changes to methods
- removed stale token tests for the above methods