### PR TITLE
Removed principalID and principalIDNS from token requests

### DIFF
--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -41,8 +41,6 @@ class WorldcatAccessToken:
                 key="my_WSKey_client_id",
                 secret="my_WSKey_secret",
                 scope="WorldCatMetadataAPI",
-                principal_id="your principalID here",
-                principal_idns="your principalIDNS here",
                 agent="my_app/1.0.0")
         >>> token.token_str
         "tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW"

--- a/bookops_worldcat/authorize.py
+++ b/bookops_worldcat/authorize.py
@@ -29,8 +29,6 @@ class WorldcatAccessToken:
         secret:                 your WSKey secret
         scopes:                 request scopes for the access token as a string,
                                 separate different scopes with space
-        principal_id:           principalID (required for read/write endpoints)
-        principal_idns:         principalIDNS (required for read/write endpoints)
         agent:                  "User-agent" parameter to be passed in the request
                                 header; usage strongly encouraged
         timeout:                how long to wait for server to send data before
@@ -75,8 +73,6 @@ class WorldcatAccessToken:
         key: str,
         secret: str,
         scopes: str,
-        principal_id: str,
-        principal_idns: str,
         agent: str = "",
         timeout: Optional[
             Union[int, float, Tuple[int, int], Tuple[float, float]]
@@ -88,8 +84,6 @@ class WorldcatAccessToken:
         self.grant_type = "client_credentials"
         self.key = key
         self.oauth_server = "https://oauth.oclc.org"
-        self.principal_id = principal_id
-        self.principal_idns = principal_idns
         self.scopes = scopes
         self.secret = secret
         self.server_response: Optional[requests.Response] = None
@@ -117,18 +111,6 @@ class WorldcatAccessToken:
                 raise ValueError("Argument 'secret' cannot be an empty string.")
         else:
             raise TypeError("Argument 'secret' must be a string.")
-
-        if isinstance(self.principal_id, str):
-            if not self.principal_id.strip():
-                raise ValueError("Argument 'principal_id' cannot be an empty string.")
-        else:
-            raise TypeError("Argument 'principal_id' must be a string.")
-
-        if isinstance(self.principal_idns, str):
-            if not self.principal_idns.strip():
-                raise ValueError("Argument 'principal_idns' cannot be an empty string.")
-        else:
-            raise TypeError("Argument 'principal_idns' must be a string.")
 
         # validate passed scopes
         if isinstance(self.scopes, str):
@@ -183,8 +165,6 @@ class WorldcatAccessToken:
         return {
             "grant_type": self.grant_type,
             "scope": self.scopes,
-            "principalID": self.principal_id,
-            "principalIDNS": self.principal_idns,
         }
 
     def _post_token_request(self) -> requests.Response:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,6 @@ def live_keys():
             os.environ["WCKey"] = data["key"]
             os.environ["WCSecret"] = data["secret"]
             os.environ["WCScopes"] = data["scopes"]
-            os.environ["WCPrincipalID"] = data["principal_id"]
-            os.environ["WCPrincipalIDNS"] = data["principal_idns"]
 
 
 class FakeUtcNow(datetime.datetime):
@@ -135,8 +133,6 @@ def mock_credentials():
         "key": "my_WSkey",
         "secret": "my_WSsecret",
         "scopes": "scope1 scope2",
-        "principal_id": "my_principalID",
-        "principal_idns": "my_principalIDNS",
     }
 
 

--- a/tests/test_authorize.py
+++ b/tests/test_authorize.py
@@ -40,8 +40,6 @@ class TestWorldcatAccessToken:
                 key=argm,
                 secret="my_secret",
                 scopes=["scope1"],
-                principal_id="my_principalID",
-                principal_idns="my_principalIDNS",
             )
         assert msg in str(exp.value)
 
@@ -71,8 +69,6 @@ class TestWorldcatAccessToken:
                 key="my_key",
                 secret=argm,
                 scopes=["scope1"],
-                principal_id="my_principalID",
-                principal_idns="my_principalIDNS",
             )
         assert msg in str(exp.value)
 
@@ -82,73 +78,9 @@ class TestWorldcatAccessToken:
                 key="my_key",
                 secret="my_secret",
                 scopes="scope1",
-                principal_id="my_principalID",
-                principal_idns="my_principalIDNS",
                 agent=124,
             )
         assert "Argument 'agent' must be a string." in str(exp.value)
-
-    def test_agent_default_values(self, mock_successful_post_token_response):
-        token = WorldcatAccessToken(
-            key="my_key",
-            secret="my_secret",
-            scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
-        )
-        assert token.agent == f"{__title__}/{__version__}"
-
-    @pytest.mark.parametrize(
-        "arg,expectation,msg",
-        [
-            (
-                None,
-                pytest.raises(TypeError),
-                "Argument 'principal_id' must be a string.",
-            ),
-            (
-                "",
-                pytest.raises(ValueError),
-                "Argument 'principal_id' cannot be an empty string.",
-            ),
-        ],
-    )
-    def test_principal_id_exception(self, arg, expectation, msg):
-        with expectation as exc:
-            WorldcatAccessToken(
-                key="my_key",
-                secret="my_secret",
-                scopes="scope1",
-                principal_id=arg,
-                principal_idns="my_principalIDNS",
-            )
-        assert msg in str(exc.value)
-
-    @pytest.mark.parametrize(
-        "arg,expectation,msg",
-        [
-            (
-                None,
-                pytest.raises(TypeError),
-                "Argument 'principal_idns' must be a string.",
-            ),
-            (
-                "",
-                pytest.raises(ValueError),
-                "Argument 'principal_idns' cannot be an empty string.",
-            ),
-        ],
-    )
-    def test_principal_idns_exception(self, arg, expectation, msg):
-        with expectation as exc:
-            WorldcatAccessToken(
-                key="my_key",
-                secret="my_secret",
-                scopes="scope1",
-                principal_id="my_principalID",
-                principal_idns=arg,
-            )
-        assert msg in str(exc.value)
 
     @pytest.mark.parametrize(
         "argm,expectation,msg",
@@ -181,8 +113,6 @@ class TestWorldcatAccessToken:
                 key="my_key",
                 secret="my_secret",
                 scopes=argm,
-                principal_id="my_principalID",
-                principal_idns="my_principalIDNS",
             )
             assert msg in str(exp.value)
 
@@ -203,8 +133,6 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
             timeout=argm,
         )
         assert token.timeout == expectation
@@ -220,8 +148,6 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes=argm,
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
         )
         assert token.scopes == expectation
 
@@ -230,8 +156,6 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
         )
         assert token._token_url() == "https://oauth.oclc.org/token"
 
@@ -240,8 +164,6 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
             agent="foo",
         )
         assert token._token_headers() == {
@@ -254,8 +176,6 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
             agent="foo",
         )
         assert token._auth() == ("my_key", "my_secret")
@@ -274,15 +194,11 @@ class TestWorldcatAccessToken:
             key="my_key",
             secret="my_secret",
             scopes="scope1",
-            principal_id="my_principalID",
-            principal_idns="my_principalIDNS",
             agent="foo",
         )
         assert token._payload() == {
             "grant_type": "client_credentials",
             "scope": "scope1",
-            "principalID": "my_principalID",
-            "principalIDNS": "my_principalIDNS",
         }
 
     def test_post_token_request_timout(self, mock_credentials, mock_timeout):
@@ -292,8 +208,6 @@ class TestWorldcatAccessToken:
                 key=creds["key"],
                 secret=creds["secret"],
                 scopes=creds["scopes"],
-                principal_id=creds["principal_id"],
-                principal_idns=creds["principal_idns"],
             )
 
     def test_post_token_request_connectionerror(
@@ -305,8 +219,6 @@ class TestWorldcatAccessToken:
                 key=creds["key"],
                 secret=creds["secret"],
                 scopes=creds["scopes"],
-                principal_id=creds["principal_id"],
-                principal_idns=creds["principal_idns"],
             )
 
     def test_post_token_request_unexpectederror(
@@ -318,8 +230,6 @@ class TestWorldcatAccessToken:
                 key=creds["key"],
                 secret=creds["secret"],
                 scopes=creds["scopes"],
-                principal_id=creds["principal_id"],
-                principal_idns=creds["principal_idns"],
             )
 
     def test_invalid_post_token_request(
@@ -331,8 +241,6 @@ class TestWorldcatAccessToken:
                 key=creds["key"],
                 secret=creds["secret"],
                 scopes=creds["scopes"],
-                principal_id=creds["principal_id"],
-                principal_idns=creds["principal_idns"],
             )
 
     def test_is_expired_false(
@@ -343,8 +251,6 @@ class TestWorldcatAccessToken:
             key=creds["key"],
             secret=creds["secret"],
             scopes=creds["scopes"],
-            principal_id=creds["principal_id"],
-            principal_idns=creds["principal_idns"],
         )
         assert token.is_expired() is False
 
@@ -376,8 +282,6 @@ class TestWorldcatAccessToken:
             key=creds["key"],
             secret=creds["secret"],
             scopes=creds["scopes"],
-            principal_id=creds["principal_id"],
-            principal_idns=creds["principal_idns"],
         )
         assert token.token_str == "tk_Yebz4BpEp9dAsghA7KpWx6dYD1OZKWBlHjqW"
         assert token.token_type == "bearer"
@@ -404,8 +308,6 @@ class TestWorldcatAccessToken:
         assert os.getenv("WCKey") is not None
         assert os.getenv("WCSecret") is not None
         assert os.getenv("WCScopes") == "WorldCatMetadataAPI"
-        assert os.getenv("WCPrincipalID") is not None
-        assert os.getenv("WCPrincipalIDNS") is not None
 
     @pytest.mark.webtest
     def test_post_token_request_with_live_service(self, live_keys):
@@ -413,8 +315,6 @@ class TestWorldcatAccessToken:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         assert token.server_response.status_code == 200

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -699,8 +699,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -714,8 +712,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
         token.token_str = "invalid-token"
         err_msg = "401 Client Error: Unauthorized for url: https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
@@ -731,8 +727,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
         with MetadataSession(authorization=token) as session:
             session.authorization.is_expired() is False
@@ -749,8 +743,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -764,8 +756,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -793,8 +783,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -850,8 +838,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -884,8 +870,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -918,8 +902,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -934,8 +916,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -963,8 +943,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:
@@ -978,8 +956,6 @@ class TestLiveMetadataSession:
             key=os.getenv("WCKey"),
             secret=os.getenv("WCSecret"),
             scopes=os.getenv("WCScopes"),
-            principal_id=os.getenv("WCPrincipalID"),
-            principal_idns=os.getenv("WCPrincipalIDNS"),
         )
 
         with MetadataSession(authorization=token) as session:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -18,8 +18,6 @@ def test_query_live(live_keys):
         key=os.getenv("WCKey"),
         secret=os.getenv("WCSecret"),
         scopes=os.getenv("WCScopes"),
-        principal_id=os.getenv("WCPrincipalID"),
-        principal_idns=os.getenv("WCPrincipalIDNS"),
     )
     with MetadataSession(authorization=token) as session:
         header = {"Accept": "application/json"}


### PR DESCRIPTION
principalID and principalIDNS are no longer required for read/write access to the Metadata API. Live tests pass on Metadata 1.0, 1.1 and 2.0 endpoints without passing principalID or principalIDNS.

See #75 