### PR TITLE
Query updates

### DIFF
--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -8,6 +8,7 @@ and others.
 from typing import Optional, Tuple, Union
 
 import requests
+from urllib3.util import Retry
 
 from . import __title__, __version__
 from .authorize import WorldcatAccessToken
@@ -34,6 +35,12 @@ class WorldcatSession(requests.Session):
                                     before giving up
         """
         super().__init__()
+
+        # allow session to retry a request up to 3 times
+        retries = Retry(
+            total=3, backoff_factor=0.5, status_forcelist=[406, 429, 500, 502, 503, 504]
+        )
+        self.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
 
         self.authorization = authorization
 

--- a/bookops_worldcat/_session.py
+++ b/bookops_worldcat/_session.py
@@ -73,18 +73,13 @@ class WorldcatSession(requests.Session):
 
         self.timeout = timeout
 
-        self.total_retries = total_retries
-        self.backoff_factor = backoff_factor
-        self.status_forcelist = status_forcelist
-        self.allowed_methods = allowed_methods
-
         # if user provides retry args, create Retry object and mount adapter to session
-        if self.total_retries != 0:
+        if total_retries != 0:
             retries = Retry(
-                total=self.total_retries,
-                backoff_factor=self.backoff_factor,
-                status_forcelist=self.status_forcelist,
-                allowed_methods=self.allowed_methods,
+                total=total_retries,
+                backoff_factor=backoff_factor,
+                status_forcelist=status_forcelist,
+                allowed_methods=allowed_methods,
             )
             self.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
 

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -207,7 +207,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumbers: Union[str, List[Union[str, int]]],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> List[Optional[Response]]:
+    ) -> List[Response]:
         """
         Retrieves Worlcat holdings status of a record with provided OCLC number.
         The service automatically recognizes institution based on the issued access

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -24,6 +24,10 @@ class MetadataSession(WorldcatSession):
         authorization: WorldcatAccessToken,
         agent: Optional[str] = None,
         timeout: Union[int, float, Tuple[int, int], Tuple[float, float], None] = None,
+        total_retries: int = 0,
+        backoff_factor: float = 0,
+        status_forcelist: Optional[List[int]] = [],
+        allowed_methods: Optional[List[str]] = None,
     ) -> None:
         """
         Args:
@@ -32,8 +36,34 @@ class MetadataSession(WorldcatSession):
                                     header; usage strongly encouraged
             timeout:                how long to wait for server to send data before
                                     giving up; default value is 5 seconds
+            total_retries:          optional number of times to retry a request that
+                                    failed or timed out. if total_retries argument is
+                                    not passed, any arguments passed to
+                                    backoff_factor, status_forcelist, and
+                                    allowed_methods will be ignored. default is 0
+            backoff_factor:         if total_retries is not 0, the backoff
+                                    factor as a float to use to calculate amount of
+                                    time session will sleep before attempting request
+                                    again. default is 0
+            status_forcelist:       if total_retries is not 0, a list of HTTP
+                                    status codes to automatically retry requests on.
+                                    if not specified, all failed requests will be
+                                    retried up to number of total_retries.
+                                    example: [500, 502, 503, 504]
+            allowed_methods:        if total_retries is not 0, set of HTTP methods that
+                                    requests should be retried on. if not specified,
+                                    requests using any HTTP method verbs will be
+                                    retried. example: ["GET", "POST"]
         """
-        super().__init__(authorization, agent=agent, timeout=timeout)
+        super().__init__(
+            authorization,
+            agent=agent,
+            timeout=timeout,
+            total_retries=total_retries,
+            backoff_factor=backoff_factor,
+            status_forcelist=status_forcelist,
+            allowed_methods=allowed_methods,
+        )
 
     def _split_into_legal_volume(
         self, oclc_numbers: List[str] = [], n: int = 50

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,18 @@ def stub_session(mock_token):
 
 
 @pytest.fixture
+def stub_retry_session(mock_token):
+    with MetadataSession(
+        authorization=mock_token,
+        total_retries=3,
+        backoff_factor=0.5,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["GET", "POST", "PUT"],
+    ) as session:
+        yield session
+
+
+@pytest.fixture
 def mock_400_response(monkeypatch):
     def mock_api_response(*args, **kwargs):
         msg = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,11 @@ class MockConnectionError:
         raise requests.exceptions.ConnectionError
 
 
+class MockRetryError:
+    def __init__(self, *args, **kwargs):
+        raise requests.exceptions.RetryError
+
+
 class MockHTTPSessionResponse(Response):
     def __init__(self, http_code):
         self.status_code = http_code
@@ -198,6 +203,13 @@ def mock_connection_error(monkeypatch):
     monkeypatch.setattr("requests.post", MockConnectionError)
     monkeypatch.setattr("requests.get", MockConnectionError)
     monkeypatch.setattr("requests.Session.send", MockConnectionError)
+
+
+@pytest.fixture
+def mock_retry_error(monkeypatch):
+    monkeypatch.setattr("requests.post", MockRetryError)
+    monkeypatch.setattr("requests.get", MockRetryError)
+    monkeypatch.setattr("requests.Session.send", MockRetryError)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,17 +24,6 @@ def live_keys():
 
 
 @pytest.fixture
-def fake_keys():
-    if os.name == "nt":
-        fh = os.path.join(os.environ["USERPROFILE"], ".oclc/nyp_wc_fake_creds.json")
-        with open(fh, "r") as file:
-            data = json.load(file)
-            os.environ["WCKey"] = data["key"]
-            os.environ["WCSecret"] = data["secret"]
-            os.environ["WCScopes"] = data["scopes"]
-
-
-@pytest.fixture
 def stub_marc_xml():
     stub_marc_xml = "<record><leader>00000nam a2200000 a 4500</leader><controlfield tag='008'>120827s2012    nyua          000 0 eng d</controlfield><datafield tag='010' ind1=' ' ind2=' '><subfield code='a'>   63011276 </subfield></datafield><datafield tag='035' ind1=' ' ind2=' '><subfield code='a'>ocn850940548</subfield></datafield><datafield tag='040' ind1=' ' ind2=' '><subfield code='a'>OCWMS</subfield><subfield code='b'>eng</subfield><subfield code='c'>OCWMS</subfield></datafield><datafield tag='100' ind1='0' ind2=' '><subfield code='a'>OCLC Developer Network</subfield></datafield><datafield tag='245' ind1='1' ind2='0'><subfield code='a'>Test Record</subfield></datafield><datafield tag='500' ind1=' ' ind2=' '><subfield code='a'>FOR OCLC DEVELOPER NETWORK DOCUMENTATION</subfield></datafield></record>"
     return stub_marc_xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,17 @@ def live_keys():
 
 
 @pytest.fixture
+def fake_keys():
+    if os.name == "nt":
+        fh = os.path.join(os.environ["USERPROFILE"], ".oclc/nyp_wc_fake_creds.json")
+        with open(fh, "r") as file:
+            data = json.load(file)
+            os.environ["WCKey"] = data["key"]
+            os.environ["WCSecret"] = data["secret"]
+            os.environ["WCScopes"] = data["scopes"]
+
+
+@pytest.fixture
 def stub_marc_xml():
     stub_marc_xml = "<record><leader>00000nam a2200000 a 4500</leader><controlfield tag='008'>120827s2012    nyua          000 0 eng d</controlfield><datafield tag='010' ind1=' ' ind2=' '><subfield code='a'>   63011276 </subfield></datafield><datafield tag='035' ind1=' ' ind2=' '><subfield code='a'>ocn850940548</subfield></datafield><datafield tag='040' ind1=' ' ind2=' '><subfield code='a'>OCWMS</subfield><subfield code='b'>eng</subfield><subfield code='c'>OCWMS</subfield></datafield><datafield tag='100' ind1='0' ind2=' '><subfield code='a'>OCLC Developer Network</subfield></datafield><datafield tag='245' ind1='1' ind2='0'><subfield code='a'>Test Record</subfield></datafield><datafield tag='500' ind1=' ' ind2=' '><subfield code='a'>FOR OCLC DEVELOPER NETWORK DOCUMENTATION</subfield></datafield></record>"
     return stub_marc_xml

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,7 +7,7 @@ import pytest
 
 from requests import Request
 
-from bookops_worldcat.errors import WorldcatRequestError, WorldcatAuthorizationError
+from bookops_worldcat.errors import WorldcatRequestError
 from bookops_worldcat.query import Query
 from bookops_worldcat.metadata_api import MetadataSession, WorldcatAccessToken
 
@@ -33,29 +33,6 @@ def test_query_live(live_keys):
             query = Query(session, prepped, timeout=5)
 
         assert query.response.status_code == 200
-
-
-@pytest.mark.webtest
-def test_failed_query_live(fake_keys):
-    token = WorldcatAccessToken(
-        key=os.getenv("WCKey"),
-        secret=os.getenv("WCSecret"),
-        scopes=os.getenv("WCScopes"),
-    )
-    with MetadataSession(authorization=token) as session:
-        header = {"Accept": "application/json"}
-        url = "https://metadata.api.oclc.org/worldcat/search/brief-bibs/41266045"
-        req = Request(
-            "GET",
-            url,
-            headers=header,
-        )
-        prepped = session.prepare_request(req)
-
-        with pytest.raises(WorldcatAuthorizationError):
-            query = Query(session, prepped, timeout=5)
-
-        assert query.response.status_code == 401
 
 
 def test_query_not_prepared_request(stub_session):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -170,3 +170,12 @@ def test_query_timeout_retry(stub_retry_session, caplog):
     assert "Retry(total=0, " in caplog.records[2].message
     assert "Retry(total=1, " in caplog.records[1].message
     assert "Retry(total=2, " in caplog.records[0].message
+
+
+def test_query_timeout_no_retry(stub_session, caplog):
+    req = Request("GET", "https://foo.org")
+    prepped = stub_session.prepare_request(req)
+    with pytest.raises(WorldcatRequestError):
+        Query(stub_session, prepped)
+
+    assert "Retry" not in caplog.records

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -161,11 +161,11 @@ def test_query_unexpected_exception(stub_session, mock_unexpected_error):
     assert "Unexpected request error: <class 'Exception'>" in str(exc.value)
 
 
-def test_query_timeout_retry(stub_session, caplog):
+def test_query_timeout_retry(stub_retry_session, caplog):
     req = Request("GET", "https://foo.org")
-    prepped = stub_session.prepare_request(req)
+    prepped = stub_retry_session.prepare_request(req)
     with pytest.raises(WorldcatRequestError):
-        Query(stub_session, prepped)
+        Query(stub_retry_session, prepped)
 
     assert "Retry(total=0, " in caplog.records[2].message
     assert "Retry(total=1, " in caplog.records[1].message

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from contextlib import nullcontext as does_not_raise
-import datetime
 import os
 
 import pytest
@@ -40,20 +39,6 @@ def test_query_not_prepared_request(stub_session):
         req = Request("GET", "https://foo.org")
         Query(stub_session, req, timeout=2)
     assert "Invalid type for argument 'prepared_request'." in str(exc.value)
-
-
-@pytest.mark.http_code(200)
-def test_query_with_stale_token(stub_session, mock_now, mock_session_response):
-    stub_session.authorization.token_expires_at = datetime.datetime.now(
-        datetime.timezone.utc
-    ) - datetime.timedelta(0, 1)
-    assert stub_session.authorization.is_expired() is True
-
-    req = Request("GET", "http://foo.org")
-    prepped = stub_session.prepare_request(req)
-    query = Query(stub_session, prepped)
-    assert stub_session.authorization.is_expired() is False
-    assert query.response.status_code == 200
 
 
 @pytest.mark.http_code(200)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -42,6 +42,20 @@ def test_query_not_prepared_request(stub_session):
 
 
 @pytest.mark.http_code(200)
+def test_query_with_stale_token(stub_session, mock_now, mock_session_response):
+    stub_session.authorization.token_expires_at = datetime.datetime.now(
+        datetime.timezone.utc
+    ) - datetime.timedelta(0, 1)
+    assert stub_session.authorization.is_expired() is True
+
+    req = Request("GET", "http://foo.org")
+    prepped = stub_session.prepare_request(req)
+    query = Query(stub_session, prepped)
+    assert stub_session.authorization.is_expired() is False
+    assert query.response.status_code == 200
+
+
+@pytest.mark.http_code(200)
 def test_query_http_200_response(stub_session, mock_session_response):
     with does_not_raise():
         req = Request("GET", "https://foo.org")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,7 +7,7 @@ import pytest
 
 from requests import Request
 
-from bookops_worldcat.errors import WorldcatRequestError
+from bookops_worldcat.errors import WorldcatRequestError, WorldcatAuthorizationError
 from bookops_worldcat.query import Query
 from bookops_worldcat.metadata_api import MetadataSession, WorldcatAccessToken
 
@@ -21,7 +21,7 @@ def test_query_live(live_keys):
     )
     with MetadataSession(authorization=token) as session:
         header = {"Accept": "application/json"}
-        url = "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
+        url = "https://metadata.api.oclc.org/worldcat/search/brief-bibs/41266045"
         req = Request(
             "GET",
             url,
@@ -33,6 +33,29 @@ def test_query_live(live_keys):
             query = Query(session, prepped, timeout=5)
 
         assert query.response.status_code == 200
+
+
+@pytest.mark.webtest
+def test_failed_query_live(fake_keys):
+    token = WorldcatAccessToken(
+        key=os.getenv("WCKey"),
+        secret=os.getenv("WCSecret"),
+        scopes=os.getenv("WCScopes"),
+    )
+    with MetadataSession(authorization=token) as session:
+        header = {"Accept": "application/json"}
+        url = "https://metadata.api.oclc.org/worldcat/search/brief-bibs/41266045"
+        req = Request(
+            "GET",
+            url,
+            headers=header,
+        )
+        prepped = session.prepare_request(req)
+
+        with pytest.raises(WorldcatAuthorizationError):
+            query = Query(session, prepped, timeout=5)
+
+        assert query.response.status_code == 401
 
 
 def test_query_not_prepared_request(stub_session):
@@ -95,9 +118,7 @@ def test_query_http_207_response(stub_session, mock_session_response):
 @pytest.mark.http_code(404)
 def test_query_http_404_response(stub_session, mock_session_response):
     header = {"Accept": "application/json"}
-    url = (
-        "https://americas.metadata.api.oclc.org/worldcat/search/v1/brief-bibs/41266045"
-    )
+    url = "https://metadata.api.oclc.org/worldcat/search/brief-bibs/41266045"
     req = Request("GET", url, headers=header, hooks=None)
     prepped = stub_session.prepare_request(req)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from contextlib import nullcontext as does_not_raise
+import datetime
 import os
 
 import pytest

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ import pytest
 
 from bookops_worldcat._session import WorldcatSession
 from bookops_worldcat.__version__ import __title__, __version__
+from requests.adapters import HTTPAdapter
 
 
 class TestWorldcatSession:
@@ -43,7 +44,7 @@ class TestWorldcatSession:
         with WorldcatSession(mock_token) as session:
             assert session.adapters["https://"].max_retries.total == 3
 
-    def test_adapter_force_list_pass(self, mock_token):
+    def test_adapter_status_forcelist(self, mock_token):
         with WorldcatSession(mock_token) as session:
             assert session.adapters["https://"].max_retries.status_forcelist == [
                 406,
@@ -53,3 +54,9 @@ class TestWorldcatSession:
                 503,
                 504,
             ]
+
+    def test_custom_adapter(self, mock_token):
+        with WorldcatSession(mock_token) as session:
+            session.mount("https://", HTTPAdapter(max_retries=2))
+            assert session.adapters["https://"].max_retries.total == 2
+            assert len(session.adapters["https://"].max_retries.status_forcelist) == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ import pytest
 
 from bookops_worldcat._session import WorldcatSession
 from bookops_worldcat.__version__ import __title__, __version__
+from requests.adapters import HTTPAdapter
 
 
 class TestWorldcatSession:
@@ -38,3 +39,7 @@ class TestWorldcatSession:
     def test_custom_timeout(self, mock_token):
         with WorldcatSession(mock_token, timeout=1) as session:
             assert session.timeout == 1
+
+    def test_adapter(self, mock_token):
+        with WorldcatSession(mock_token) as session:
+            assert isinstance(session.adapters["https://"], HTTPAdapter)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,7 +5,6 @@ import pytest
 
 from bookops_worldcat._session import WorldcatSession
 from bookops_worldcat.__version__ import __title__, __version__
-from requests.adapters import HTTPAdapter
 
 
 class TestWorldcatSession:
@@ -40,6 +39,17 @@ class TestWorldcatSession:
         with WorldcatSession(mock_token, timeout=1) as session:
             assert session.timeout == 1
 
-    def test_adapter(self, mock_token):
+    def test_adapter_retry_total(self, mock_token):
         with WorldcatSession(mock_token) as session:
-            assert isinstance(session.adapters["https://"], HTTPAdapter)
+            assert session.adapters["https://"].max_retries.total == 3
+
+    def test_adapter_force_list_pass(self, mock_token):
+        with WorldcatSession(mock_token) as session:
+            assert session.adapters["https://"].max_retries.status_forcelist == [
+                406,
+                429,
+                500,
+                502,
+                503,
+                504,
+            ]


### PR DESCRIPTION
Edited to reflect changes:

Added option for users to add automatic retries to requests
- added `total_retries`, `backoff_factor`, `status_forcelist`, and `allowed_methods` as args in `WorldcatSession` and `MetadataSession`
- default number of retries is 0
- added tests to all modules and live tests of retries to `test_metadata_api.py`

Somewhat related: there's an open enhancement request for `requests` asking to be able to refresh authentication header on retry. That functionality doesn't currently exist and it doesn't look like it's being worked on
https://github.com/psf/requests/issues/5975