### PR TITLE
pyproject classifiers update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,17 +13,18 @@ homepage = "https://bookops-cat.github.io/bookops-worldcat/"
 keywords = ["api", "api-wrapper", "oclc", "worldcat", "cataloging", "bibliographic records", "marcxml", "holdings", "library metadata"]
 
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Education",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]


### PR DESCRIPTION
Updates `pyproject.toml` classifiers important for PyPI:

- Development Status to 5 - Production/Stable
- Drops Python 3.7 support
- Adds Python 3.11 & 3.12 support