### PR TITLE
oclcNumbers type fixes

### DIFF
--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -269,7 +269,7 @@ class MetadataSession(WorldcatSession):
 
     def bib_get_current_oclc_number(
         self,
-        oclcNumbers: Union[str, List[Union[str, int]]],
+        oclcNumbers: Union[int, str, List[Union[str, int]]],
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
@@ -277,10 +277,11 @@ class MetadataSession(WorldcatSession):
         Uses /manage/bibs/current endpoint.
 
         Args:
-            oclcNumbers:            string or list containing one or more OCLC numbers
-                                    to be checked; numbers can be integers or strings
-                                    with or without OCLC Number prefix;
+            oclcNumbers:            int, string or list containing one or more
+                                    OCLC numbers to be checked; numbers can be integers
+                                    or strings with or without OCLC Number prefix;
                                     if str, the numbers must be separated by a comma
+                                    if int, only one number may be passed as an arg
             hooks:                  Requests library hook system that can be used for
                                     signal event handling. For more information see the
                                     [Requests docs](https://requests.readthedocs.io/en/
@@ -854,7 +855,7 @@ class MetadataSession(WorldcatSession):
 
     def holdings_get_current(
         self,
-        oclcNumbers: Union[str, List[Union[str, int]]],
+        oclcNumbers: Union[int, str, List[Union[str, int]]],
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
@@ -864,10 +865,11 @@ class MetadataSession(WorldcatSession):
         Uses /manage/institution/holdings/current endpoint.
 
         Args:
-            oclcNumbers:            string or list containing one or more OCLC numbers
-                                    to be checked; numbers can be integers or strings
-                                    with or without OCLC Number prefix;
+            oclcNumbers:            int, string or list containing one or more
+                                    OCLC numbers to be checked; numbers can be integers
+                                    or strings with or without OCLC Number prefix;
                                     if str, the numbers must be separated by a comma
+                                    if int, only one number may be passed as an arg
             hooks:                  Requests library hook system that can be used for
                                     signal event handling. For more information see the
                                     [Requests docs](https://requests.readthedocs.io/en/

--- a/bookops_worldcat/utils.py
+++ b/bookops_worldcat/utils.py
@@ -61,7 +61,9 @@ def verify_oclc_number(oclcNumber: Union[int, str]) -> str:
         raise InvalidOclcNumber("Argument 'oclcNumber' is of invalid type.")
 
 
-def verify_oclc_numbers(oclcNumbers: Union[str, List[Union[str, int]]]) -> List[str]:
+def verify_oclc_numbers(
+    oclcNumbers: Union[int, str, List[Union[str, int]]]
+) -> List[str]:
     """
     Parses and verifies list of oclcNumbers
 
@@ -70,7 +72,8 @@ def verify_oclc_numbers(oclcNumbers: Union[str, List[Union[str, int]]]) -> List[
                                 should be set;
                                 they can be integers or strings with or without
                                 OCLC # prefix;
-                                if str the numbers must be separated by comma
+                                if str, the numbers must be separated by comma
+                                if int, only one number will be parsed
 
     Returns:
         vetted_numbers as list
@@ -78,17 +81,19 @@ def verify_oclc_numbers(oclcNumbers: Union[str, List[Union[str, int]]]) -> List[
     """
     if isinstance(oclcNumbers, str):
         oclcNumbers_lst = _str2list(oclcNumbers)
+    elif isinstance(oclcNumbers, int):
+        oclcNumbers_lst = _str2list(str(oclcNumbers))
     elif isinstance(oclcNumbers, list):
         oclcNumbers_lst = oclcNumbers  # type: ignore
     else:
         raise InvalidOclcNumber(
-            "Argument 'oclcNumbers' must be a list or comma separated string "
-            "of valid OCLC #s."
+            "Argument 'oclcNumbers' must be a single integer, a list or a "
+            "comma separated string of valid OCLC #s."
         )
     if not oclcNumbers_lst:
         raise InvalidOclcNumber(
-            "Argument 'oclcNumbers' must be a list or comma separated string "
-            "of valid OCLC #s."
+            "Argument 'oclcNumbers' must be a single integer, a list or a "
+            "comma separated string of valid OCLC #s."
         )
 
     vetted_numbers = [verify_oclc_number(n) for n in oclcNumbers_lst]

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -288,29 +288,21 @@ class TestMockedMetadataSession:
         with pytest.raises(TypeError):
             stub_session.bib_get_classification()
 
-    @pytest.mark.http_code(207)
-    def test_bib_get_current_oclc_number(self, stub_session, mock_session_response):
-        assert (
-            stub_session.bib_get_current_oclc_number(
-                oclcNumbers=["12345", "65891"]
-            ).status_code
-            == 207
-        )
-
-    @pytest.mark.http_code(207)
-    def test_bib_get_current_oclc_number_passed_as_str(
-        self, stub_session, mock_session_response
+    @pytest.mark.parametrize(
+        "argm", ["12345, 65891", ["12345", "65891"], 12345, ["12345", 12345]]
+    )
+    @pytest.mark.http_code(200)
+    def test_bib_get_current_oclc_number(
+        self, argm, stub_session, mock_session_response
     ):
         assert (
-            stub_session.bib_get_current_oclc_number(
-                oclcNumbers="12345,65891"
-            ).status_code
-            == 207
+            stub_session.bib_get_current_oclc_number(oclcNumbers=argm).status_code
+            == 200
         )
 
     @pytest.mark.parametrize("argm", [(None), (""), ([])])
     def test_bib_get_current_oclc_number_missing_numbers(self, stub_session, argm):
-        err_msg = "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s."
+        err_msg = "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s."
         with pytest.raises(InvalidOclcNumber) as exc:
             stub_session.bib_get_current_oclc_number(argm)
         assert err_msg in str(exc.value)
@@ -417,9 +409,13 @@ class TestMockedMetadataSession:
     def test_holdings_get_codes(self, stub_session, mock_session_response):
         assert stub_session.holdings_get_codes().status_code == 200
 
+    @pytest.mark.parametrize(
+        "argm",
+        ["12345", 12345, ["12345", 12345], "12345, 67890"],
+    )
     @pytest.mark.http_code(200)
-    def test_holdings_get_current(self, stub_session, mock_session_response):
-        assert stub_session.holdings_get_current("12345").status_code == 200
+    def test_holdings_get_current(self, argm, stub_session, mock_session_response):
+        assert stub_session.holdings_get_current(argm).status_code == 200
 
     def test_holdings_get_current_no_oclcNumber_passed(self, stub_session):
         with pytest.raises(TypeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,27 +101,27 @@ class TestUtils:
             (
                 None,
                 pytest.raises(InvalidOclcNumber),
-                "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s.",
+                "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s.",
             ),
             (
                 "",
                 pytest.raises(InvalidOclcNumber),
-                "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s.",
+                "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s.",
             ),
             (
                 [],
                 pytest.raises(InvalidOclcNumber),
-                "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s.",
+                "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s.",
             ),
             (
                 ",,",
                 pytest.raises(InvalidOclcNumber),
-                "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s.",
+                "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s.",
             ),
             (
                 12345.5,
                 pytest.raises(InvalidOclcNumber),
-                "Argument 'oclcNumbers' must be a list or comma separated string of valid OCLC #s.",
+                "Argument 'oclcNumbers' must be a single integer, a list or a comma separated string of valid OCLC #s.",
             ),
             (
                 "bt12345",
@@ -148,6 +148,7 @@ class TestUtils:
             ("ocm0012345, ocm67890", ["12345", "67890"]),
             ([12345, 67890], ["12345", "67890"]),
             (["ocn12345", "on67890"], ["12345", "67890"]),
+            (12345, ["12345"]),
         ],
     )
     def test_verify_oclc_numbers_parsing(self, argm, expectation):


### PR DESCRIPTION
Fixing bug mentioned in #95 

#### Added:
 + `int` type to `oclcNumbers` arg in `MetadataSession` methods `holdings_get_current` and `bib_get_current_oclc_number` and `utils.py` function `verify_oclc_numbers`
#### Changed:
 + `verify_oclc_numbers` function in `utils.py` to handle `int` args
 + refactored tests to test `int`, `str`, and `list` args in `holdings_get_current`, `bib_get_current_oclc_number` and `verify_oclc_numbers`