### PR TITLE
response type for metadata api methods is Response

### DIFF
--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -172,7 +172,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Create a bib record in OCLC if it does not already exist.
 
@@ -217,7 +217,7 @@ class MetadataSession(WorldcatSession):
         oclcNumber: Union[int, str],
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Send a GET request for a full bib record.
 
@@ -257,7 +257,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumber: Union[int, str],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given an OCLC number, retrieve classification recommendations for the bib
         record.
@@ -294,7 +294,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumbers: Union[int, str, List[Union[str, int]]],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given one or more OCLC Numbers, retrieve current OCLC numbers.
 
@@ -338,7 +338,7 @@ class MetadataSession(WorldcatSession):
         record: Union[str, bytes, BinaryIO],
         recordFormat: str,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a bib record in MARC21 or MARCXML identify the best match in WorldCat.
         Record must contain at minimum an 008 and 245. Response contains number of
@@ -383,7 +383,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given an OCLC number and MARC record, find record in WorldCat and replace it.
         If the record does not exist in WorldCat, a new bib record will be created.
@@ -432,7 +432,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         validationLevel: str = "validateFull",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a bib record, validate that record conforms to MARC standards.
 
@@ -491,7 +491,7 @@ class MetadataSession(WorldcatSession):
 
     def brief_bibs_get(
         self, oclcNumber: Union[int, str], hooks: Optional[Dict[str, Callable]] = None
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieve specific brief bibliographic resource.
 
@@ -559,7 +559,7 @@ class MetadataSession(WorldcatSession):
         offset: int = 1,
         limit: int = 10,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Search for brief bibliographic resources using WorldCat query syntax.
         See OCLC
@@ -783,7 +783,7 @@ class MetadataSession(WorldcatSession):
         limit: int = 10,
         orderBy: str = "publicationDateDesc",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieve other editions related to bibliographic resource with provided
         OCLC Number. Query may contain only one of: `heldByInstitutionID`,
@@ -945,7 +945,7 @@ class MetadataSession(WorldcatSession):
     def holdings_get_codes(
         self,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieve the all holding codes for the authenticated institution.
 
@@ -976,7 +976,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumbers: Union[int, str, List[Union[str, int]]],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieves WorldCat holdings status of a record with provided OCLC number.
         The service automatically recognizes the user's institution based on the
@@ -1025,7 +1025,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumber: Union[int, str],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Sets institution's WorldCat holdings on an individual record.
 
@@ -1061,7 +1061,7 @@ class MetadataSession(WorldcatSession):
         self,
         oclcNumber: Union[int, str],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Unsets institution's WorldCat holdings on an individual record.
 
@@ -1098,7 +1098,7 @@ class MetadataSession(WorldcatSession):
         record: str,
         recordFormat: str,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a MARC record in MARCXML or MARC21, set institution holdings on the
         record. MARC record must contain OCLC number in 001 or 035 subfield a.
@@ -1141,7 +1141,7 @@ class MetadataSession(WorldcatSession):
         record: str,
         recordFormat: str,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a MARC record in MARCXML or MARC21, unset institution holdings on the
         record. MARC record must contain OCLC number in 001 or 035 subfield a.
@@ -1184,7 +1184,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a local bibliographic data record, create it in WorldCat.
 
@@ -1229,7 +1229,7 @@ class MetadataSession(WorldcatSession):
         controlNumber: Union[int, str],
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a control number, delete the associated Local Bibliographic Data record.
 
@@ -1268,7 +1268,7 @@ class MetadataSession(WorldcatSession):
         controlNumber: Union[int, str],
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a Control Number, retrieve a Local Bibliographic Data record.
 
@@ -1309,7 +1309,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a Control Number, find the associated Local Bibliographic Data
         Record and replace it. If the Control Number is not found in
@@ -1360,7 +1360,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a local holdings record, create it in WorldCat
 
@@ -1405,7 +1405,7 @@ class MetadataSession(WorldcatSession):
         controlNumber: Union[int, str],
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a control number, delete a Local Holdings record.
 
@@ -1444,7 +1444,7 @@ class MetadataSession(WorldcatSession):
         controlNumber: Union[int, str],
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Send a GET request for a local holdings record
 
@@ -1485,7 +1485,7 @@ class MetadataSession(WorldcatSession):
         recordFormat: str,
         responseFormat: str = "application/marcxml+xml",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a Control Number, find the associated Local Holdings
         Record and replace it. If the Control Number is not found in
@@ -1534,7 +1534,7 @@ class MetadataSession(WorldcatSession):
         self,
         controlNumber: Union[int, str],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieve LBD Resource.
 
@@ -1570,7 +1570,7 @@ class MetadataSession(WorldcatSession):
         offset: int = 1,
         limit: int = 10,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Search LBD Resources using WorldCat query syntax. See OCLC
         [Local Bibliographic Data Record Index](https://help.oclc.org/Librarian_Toolbox/Searching_WorldCat_Indexes/Local_bibliographic_data_records/Local_bibliographic_data_record_indexes_A-Z)
@@ -1626,7 +1626,7 @@ class MetadataSession(WorldcatSession):
         browsePosition: int = 0,
         limit: int = 10,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Browse local holdings.
 
@@ -1683,7 +1683,7 @@ class MetadataSession(WorldcatSession):
         self,
         controlNumber: Union[int, str],
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Retrieve LHR Resource.
 
@@ -1721,7 +1721,7 @@ class MetadataSession(WorldcatSession):
         offset: int = 1,
         limit: int = 10,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Search LHR Resources. Query must contain, at minimum, either an
         `oclcNumber` or `barcode`.
@@ -1785,7 +1785,7 @@ class MetadataSession(WorldcatSession):
         offset: int = 1,
         limit: int = 10,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Search for shared print LHR Resources. Query must contain, at minimum,
         either an `oclcNumber` or `barcode` and a value for either
@@ -1859,7 +1859,7 @@ class MetadataSession(WorldcatSession):
         itemType: Optional[List[str]] = None,
         itemSubType: Optional[List[str]] = None,
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Finds member shared print holdings for specified item. Query must
         contain, at minimum, either an `oclcNumber`, `isbn`, or `issn`.
@@ -1944,7 +1944,7 @@ class MetadataSession(WorldcatSession):
         distance: Optional[int] = None,
         unit: str = "M",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given a known item, get summary of holdings and brief bib record. Query must
         contain, at minimum, either an OCLC Number, ISBN, or ISSN. Query may contain
@@ -2074,7 +2074,7 @@ class MetadataSession(WorldcatSession):
         distance: Optional[int] = None,
         unit: str = "M",
         hooks: Optional[Dict[str, Callable]] = None,
-    ) -> Optional[Response]:
+    ) -> Response:
         """
         Given an OCLC number, get summary of holdings. Query may contain
         only one of: `heldByInstitutionId`, `heldByGroup`, `heldBySymbol`,


### PR DESCRIPTION
Changed response type for all `MetadataSession` methods from `Optional[requests.Response]` to `requests.Response`