### PR TITLE
Holdings unset updates

### DIFF
--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -1060,6 +1060,7 @@ class MetadataSession(WorldcatSession):
     def holdings_unset(
         self,
         oclcNumber: Union[int, str],
+        cascadeDelete: bool = True,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
@@ -1071,6 +1072,11 @@ class MetadataSession(WorldcatSession):
             oclcNumber:
                 OCLC bibliographic record number. Can be an integer or string
                 with or without OCLC Number prefix.
+            cascadeDelete:
+                Whether or not to remove any LBDs and/or LHRs associated with
+                the bib record on which holdings are being removed. If `False`,
+                associated local records will remain in WorldCat. If `True`,
+                local records will be removed from WorldCat.
             hooks:
                 Requests library hook system that can be used for signal event
                 handling. For more information see the [Requests docs](https://requests.
@@ -1084,8 +1090,10 @@ class MetadataSession(WorldcatSession):
         url = self._url_manage_ih_unset(oclcNumber)
         header = {"Accept": "application/json"}
 
+        payload = {"cascadeDelete": cascadeDelete}
+
         # prep request
-        req = Request("POST", url, headers=header, hooks=hooks)
+        req = Request("POST", url, params=payload, headers=header, hooks=hooks)
         prepared_request = self.prepare_request(req)
 
         # send request
@@ -1140,6 +1148,7 @@ class MetadataSession(WorldcatSession):
         self,
         record: str,
         recordFormat: str,
+        cascadeDelete: bool = True,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Optional[Response]:
         """
@@ -1156,6 +1165,11 @@ class MetadataSession(WorldcatSession):
                 Format of MARC record.
 
                 **OPTIONS:** `'application/marcxml+xml'` or `'application/marc'`
+            cascadeDelete:
+                Whether or not to remove any LBDs and/or LHRs associated with
+                the bib record on which holdings are being removed. If `False`,
+                associated local records will remain in WorldCat. If `True`,
+                local records will be removed from WorldCat.
             hooks:
                 Requests library hook system that can be used for signal event
                 handling. For more information see the [Requests docs](https://requests.
@@ -1164,14 +1178,24 @@ class MetadataSession(WorldcatSession):
         Returns:
             `requests.Response` instance
         """
+
         url = self._url_manage_ih_unset_with_bib()
         header = {
             "Accept": "application/json",
             "content-type": recordFormat,
         }
 
+        payload = {"cascadeDelete": cascadeDelete}
+
         # prep request
-        req = Request("POST", url, data=record, headers=header, hooks=hooks)
+        req = Request(
+            "POST",
+            url,
+            data=record,
+            params=payload,
+            headers=header,
+            hooks=hooks,
+        )
         prepared_request = self.prepare_request(req)
 
         # send request

--- a/docs/local.md
+++ b/docs/local.md
@@ -1,6 +1,7 @@
 # Search and Manage Local Data
 New functionality available in Version 1.0 of Bookops-Worldcat allows users to search and manage local bibliographic and holdings data via the Metadata API. 
 
+Users can also manage local bibliographic and holdings data when managing institution holdings. When unsetting holdings on a record in OCLC, users can remove associated LBDs and/or LHRs. See[Manage Institution Holdings > Set and Unset Holdings](manage_holdings.md#set-and-unset-holdings) for more information.
 
 ### Manage Local Bib Records
 Users can manage local bib records in WorldCat in the same way that they manage WorldCat records (see [Managing Bibliographic Records](manage_bibs.md) for more information). Records can be retrieved in MARCXML or MARC21 formats. The default format for records is MARCXML.  

--- a/docs/manage_holdings.md
+++ b/docs/manage_holdings.md
@@ -60,6 +60,8 @@ Version 2.0 of the Metadata API provides new functionality to set and unset hold
 
 Bookops-Worldcat supports this functionality with the `holdings_set_with_bib` and `holdings_unset_with_bib` methods which can be passed a MARC record in the body of the request in the same way that one would pass a record to a method that uses any of the `/manage/bibs/` endpoints.
 
+Beginning in September 2024 users are able to remove associated Local Bibliographic Data and/or Local Holdings Records when unsetting holdings on a record in OCLC. This functionality is supported by both the `/worldcat/manage/institution/holdings/unset` and `/worldcat/manage/institution/holdings/{oclcNumber}/unset` endpoints using the `cascadeDelete` arg. If `cascadeDelete` is `True`, local records will be removed from WorldCat when unsetting a holding. If `False`, the associated local records will remain in WorldCat. The default value within `bookops-worldcat` and the Metadata API is `True` 
+
 === "holdings_set"
 
     ```python title="holdings_set Request"


### PR DESCRIPTION
 - Following September 2024 update to Metadata API, added `cascadeDelete` as an arg for `MetadataSession.holdings_unset` and `MetadataSession.holdings_unset_with_bib`
 - Updated docs to reflect changes to `holdings_unset` and `holdings_unset_with_bib` methods