### PR TITLE
Search institution endpoint

### DIFF
--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -1118,7 +1118,7 @@ class MetadataSession(WorldcatSession):
         """
         Sets institution's WorldCat holdings on an individual record.
 
-        Uses /manage/institions/holdings/{oclcNumber}/set endpoint.
+        Uses /manage/institution/holdings/{oclcNumber}/set endpoint.
 
         Args:
             oclcNumber:
@@ -1155,7 +1155,7 @@ class MetadataSession(WorldcatSession):
         """
         Unsets institution's WorldCat holdings on an individual record.
 
-        Uses /manage/institions/holdings/{oclcNumber}/unset endpoint.
+        Uses /manage/institution/holdings/{oclcNumber}/unset endpoint.
 
         Args:
             oclcNumber:

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -1291,14 +1291,14 @@ class MetadataSession(WorldcatSession):
         query = Query(self, prepared_request, timeout=self.timeout)
         return query.response
 
-    def institution_indentifiers_get(
+    def institution_identifiers_get(
         self,
         registryIds: Optional[Union[str, int, List[str], List[int]]] = None,
         oclcSymbols: Optional[Union[str, List[str]]] = None,
         hooks: Optional[Dict[str, Callable]] = None,
     ) -> Response:
         """
-        Retrieve identifiers for an institution based on registry IDs or OCLC symbol.
+        Retrieve identifiers for an institution based on registry IDs or OCLC symbols.
         Query must contain either `registryIds` or `oclcSymbols` but not both.
 
         Uses /search/institution endpoint.

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -9,7 +9,7 @@ from requests import Request, Response
 from ._session import WorldcatSession
 from .authorize import WorldcatAccessToken
 from .query import Query
-from .utils import verify_oclc_number, verify_oclc_numbers
+from .utils import verify_ids, verify_oclc_number, verify_oclc_numbers
 
 
 class MetadataSession(WorldcatSession):
@@ -153,6 +153,9 @@ class MetadataSession(WorldcatSession):
 
     def _url_search_classification_bibs(self, oclcNumber: str) -> str:
         return f"{self.BASE_URL}/search/classification-bibs/{oclcNumber}"
+
+    def _url_search_institution(self) -> str:
+        return f"{self.BASE_URL}/search/institution"
 
     def _url_search_lhr_shared_print(self) -> str:
         return f"{self.BASE_URL}/search/retained-holdings"
@@ -1286,6 +1289,65 @@ class MetadataSession(WorldcatSession):
 
         # send request
         query = Query(self, prepared_request, timeout=self.timeout)
+        return query.response
+
+    def institution_indentifiers_get(
+        self,
+        registryIds: Optional[Union[str, int, List[str], List[int]]] = None,
+        oclcSymbols: Optional[Union[str, List[str]]] = None,
+        hooks: Optional[Dict[str, Callable]] = None,
+    ) -> Response:
+        """
+        Retrieve identifiers for an institution based on registry IDs or OCLC symbol.
+        Query must contain either `registryIds` or `oclcSymbols` but not both.
+
+        Uses /search/institution endpoint.
+
+        Args:
+            registryId:
+                One or more registry IDs to retrieve identifiers for.
+                May be a string, integer, or list of strings and/or integers.
+                If a string, multiple IDs must be separated by a comma.
+
+                **EXAMPLES:**
+
+                - `58122`
+                - `58122,12337`
+                - `58122, 12337`
+                - `['58122', '12337']`
+            oclcSymbols:
+                One or more OCLC symbols to retrieve identifiers for.
+                May be a string or a list of strings. If a string, multiple
+                symbols must be separated by a comma.
+
+                **EXAMPLES:**
+
+                - `NYP`
+                - `NYP,BKL`
+                - `NYP, BKL`
+                - `['NYP', 'BKL']
+            hooks:
+                Requests library hook system that can be used for signal event
+                handling. For more information see the [Requests docs](https://requests.
+                readthedocs.io/en/master/user/advanced/#event-hooks)
+
+        Returns:
+            `requests.Response` instance
+        """
+        url = self._url_search_institution()
+        header = {"Accept": "application/json"}
+
+        registry_ids = verify_ids(registryIds)
+        oclc_symbols = verify_ids(oclcSymbols)
+        payload = {"registryIds": registry_ids, "oclcSymbols": oclc_symbols}
+
+        # prep request
+        req = Request("GET", url, params=payload, headers=header, hooks=hooks)
+        prepared_request = self.prepare_request(req)
+
+        # send request
+        query = Query(self, prepared_request, timeout=self.timeout)
+
         return query.response
 
     def lbd_create(

--- a/bookops_worldcat/metadata_api.py
+++ b/bookops_worldcat/metadata_api.py
@@ -1304,7 +1304,7 @@ class MetadataSession(WorldcatSession):
         Uses /search/institution endpoint.
 
         Args:
-            registryId:
+            registryIds:
                 One or more registry IDs to retrieve identifiers for.
                 May be a string, integer, or list of strings and/or integers.
                 If a string, multiple IDs must be separated by a comma.

--- a/bookops_worldcat/utils.py
+++ b/bookops_worldcat/utils.py
@@ -3,6 +3,7 @@
 """
 Shared utilities module.
 """
+
 import re
 from typing import List, Union
 
@@ -46,6 +47,42 @@ def prep_oclc_number_str(oclcNumber: str) -> str:
         raise InvalidOclcNumber("Argument 'oclcNumber' does not look like real OCLC #.")
 
 
+def verify_ids(
+    ids: Union[str, int, List[str], List[int], None],
+) -> Union[str, None]:
+    """
+    Parses list of registry IDs or OCLC symbols. IDs will be joined
+    and returned as a comma-separated string if more than one id
+    is passed.
+
+    Args:
+        ids:
+            one or more institution registry ID(s) or OCLC symbol(s)
+
+            **EXAMPLES:**
+
+            - "58122"
+            - "58122,13437"
+            - "58122, 13437"
+            - ["58122", 13437]
+            - "BKL"
+            - "BKL,NYP"
+            - ["BKL"]
+            - ["BKL", "NYP"]
+
+    Returns:
+        ids as a string or None
+    """
+    if isinstance(ids, int):
+        return str(ids)
+    elif isinstance(ids, str):
+        return ",".join([str(i.strip()) for i in ids.split(",")])
+    elif isinstance(ids, list):
+        return ",".join([str(i) for i in ids])
+    else:
+        return ids
+
+
 def verify_oclc_number(oclcNumber: Union[int, str]) -> str:
     """
     Verifies a valid looking OCLC number is passed and normalize it as integer.
@@ -74,7 +111,7 @@ def verify_oclc_number(oclcNumber: Union[int, str]) -> str:
 
 
 def verify_oclc_numbers(
-    oclcNumbers: Union[int, str, List[Union[str, int]]]
+    oclcNumbers: Union[int, str, List[Union[str, int]]],
 ) -> List[str]:
     """
     Parses and verifies list of oclcNumbers

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 ## [1.2.0] - (6/16/2025)
 ### Added
  - Added `branch_holding_codes_get()` method to support `/worldcat/manage/institution-config/branch-shelving-locations` endpoint
+ - Added `institution_identifiers_get()` method to support `/worldcat/search/institution` endpoint
+ - `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API
 
 ### Changed
  - restructured `pyproject.toml` following the changes implemented with poetry 2.0. Several sections of the `pyproject.toml` file have been moved from the `tool.poetry` section to the `project` section. 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,10 @@
 
 ## [1.2.0] - (6/16/2025)
 ### Added
- - Added `branch_holding_codes_get()` method to support `/worldcat/manage/institution-config/branch-shelving-locations` endpoint
- - Added `institution_identifiers_get()` method to support `/worldcat/search/institution` endpoint
- - `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API
+ - Added support for new new Metadata API functionality:
+   - `MetadataSession.branch_holding_codes_get()` allows users to retrieve branch holding codes and shelving locations using the `/worldcat/manage/institution-config/branch-shelving-locations` endpoint
+   - `MetadataSession.institution_identifiers_get()` allows users to retrieve retrieve the Registry ID and OCLC Symbols for one or more institutions using the `/worldcat/search/institution` endpoint
+ - Added `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API
 
 ### Changed
  - restructured `pyproject.toml` following the changes implemented with poetry 2.0. Several sections of the `pyproject.toml` file have been moved from the `tool.poetry` section to the `project` section. 

--- a/docs/manage_holdings.md
+++ b/docs/manage_holdings.md
@@ -1,6 +1,6 @@
 # Manage Institution Holdings
 
-Server responses are returned in JSON format for requests made to any `/manage/holdings/` endpoints. These responses can be accessed and parsed with the `.json()` method.
+Server responses are returned in JSON format for requests made to any `/manage/holdings/` or `/search/institution/` endpoints. These responses can be accessed and parsed with the `.json()` method.
 
 ## Get Institution Holdings Codes
 
@@ -56,6 +56,31 @@ with MetadataSession(authorization=token) as session:
 }
 ```
 
+### Get Identifiers for an Institution
+
+Users can retrieve the Registry ID and OCLC Symbol(s) for an institution by passing one or more Registry IDs or OCLC Symbols to the `institution_identifiers_get` method. Users can pass more than one value to the web service but should only pass Registry IDs or OCLC Symbols but not both. 
+
+```python title="institution_identifiers_get Request"
+from bookops_worldcat import MetadataSession
+
+with MetadataSession(authorization=token) as session:
+    response = session.institution_identifiers_get(oclcSymbols='NYP,BKL')
+    print(response.json())
+```
+```{ .json title="holdings_get_codes Response" .no-copy}
+{
+  "entries": [
+    {
+      "oclcSymbols": ["NYP"],
+      "registryId": 58122
+    },
+    {
+      "oclcSymbols": ["BKL"],
+      "registryId": 13437
+    },    
+  ]
+}
+```
 ## Get Current Holdings
 The `holdings_get_current` method retrieves the holding status of a requested record for the authenticated institution.
 

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -164,6 +164,12 @@ class TestMockedMetadataSession:
             == f"https://metadata.api.oclc.org/worldcat/manage/lhrs/{controlNumber}"
         )
 
+    def test_url_search_institution(self, stub_session):
+        assert (
+            stub_session._url_search_institution()
+            == "https://metadata.api.oclc.org/worldcat/search/institution"
+        )
+
     def test_url_search_shared_print_holdings(self, stub_session):
         assert (
             stub_session._url_search_shared_print_holdings()
@@ -522,6 +528,24 @@ class TestMockedMetadataSession:
             stub_session.holdings_unset_with_bib(
                 record=stub_marc_xml, recordFormat="application/marcxml+xml"
             ).status_code
+            == 200
+        )
+
+    @pytest.mark.http_code(200)
+    def test_institution_indentifiers_get_oclc_symbols(
+        self, stub_session, mock_session_response
+    ):
+        assert (
+            stub_session.institution_indentifiers_get(oclcSymbols="FOO").status_code
+            == 200
+        )
+
+    @pytest.mark.http_code(200)
+    def test_institution_indentifiers_get_registry_id(
+        self, stub_session, mock_session_response
+    ):
+        assert (
+            stub_session.institution_indentifiers_get(registryIds="12345").status_code
             == 200
         )
 

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -532,20 +532,20 @@ class TestMockedMetadataSession:
         )
 
     @pytest.mark.http_code(200)
-    def test_institution_indentifiers_get_oclc_symbols(
+    def test_institution_identifiers_get_oclc_symbols(
         self, stub_session, mock_session_response
     ):
         assert (
-            stub_session.institution_indentifiers_get(oclcSymbols="FOO").status_code
+            stub_session.institution_identifiers_get(oclcSymbols="FOO").status_code
             == 200
         )
 
     @pytest.mark.http_code(200)
-    def test_institution_indentifiers_get_registry_id(
+    def test_institution_identifiers_get_registry_id(
         self, stub_session, mock_session_response
     ):
         assert (
-            stub_session.institution_indentifiers_get(registryIds="12345").status_code
+            stub_session.institution_identifiers_get(registryIds="12345").status_code
             == 200
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,13 +2,14 @@
 
 import pytest
 
+from bookops_worldcat.errors import InvalidOclcNumber
 from bookops_worldcat.utils import (
     _str2list,
     prep_oclc_number_str,
+    verify_ids,
     verify_oclc_number,
     verify_oclc_numbers,
 )
-from bookops_worldcat.errors import InvalidOclcNumber
 
 
 class TestUtils:
@@ -51,6 +52,28 @@ class TestUtils:
     )
     def test_str2list(self, argm, expectation):
         assert _str2list(argm) == expectation
+
+    @pytest.mark.parametrize(
+        "argm,expectation",
+        [
+            ("58122,13437", "58122,13437"),
+            ("58122, 13437", "58122,13437"),
+            (["58122", 13437], "58122,13437"),
+            (["58122", "13437"], "58122,13437"),
+            ([58122, 13437], "58122,13437"),
+            (58122, "58122"),
+            ("58122", "58122"),
+            ([58122], "58122"),
+            (["58122"], "58122"),
+            ("BKL,NYP", "BKL,NYP"),
+            ("BKL, NYP", "BKL,NYP"),
+            (["BKL", "NYP"], "BKL,NYP"),
+            ("BKL", "BKL"),
+            (["BKL"], "BKL"),
+        ],
+    )
+    def test_verify_ids(self, argm, expectation):
+        assert verify_ids(argm) == expectation
 
     @pytest.mark.parametrize(
         "argm,expectation,msg",

--- a/tests/webtests/test_api_spec.py
+++ b/tests/webtests/test_api_spec.py
@@ -314,6 +314,16 @@ class TestAPISpec:
         method_args = self.params_from_method(MetadataSession.holdings_unset_with_bib)
         assert endpoint_args == method_args
 
+    @pytest.mark.holdings
+    def test_params_institution_indentifiers_get(self):
+        endpoint_args = self.params_from_yaml(
+            MetadataSession.institution_indentifiers_get
+        )
+        method_args = self.params_from_method(
+            MetadataSession.institution_indentifiers_get
+        )
+        assert endpoint_args == method_args
+
     def test_params_shared_print_holdings_search(self):
         endpoint_args = self.params_from_yaml(
             MetadataSession.shared_print_holdings_search

--- a/tests/webtests/test_api_spec.py
+++ b/tests/webtests/test_api_spec.py
@@ -315,12 +315,12 @@ class TestAPISpec:
         assert endpoint_args == method_args
 
     @pytest.mark.holdings
-    def test_params_institution_indentifiers_get(self):
+    def test_params_institution_identifiers_get(self):
         endpoint_args = self.params_from_yaml(
-            MetadataSession.institution_indentifiers_get
+            MetadataSession.institution_identifiers_get
         )
         method_args = self.params_from_method(
-            MetadataSession.institution_indentifiers_get
+            MetadataSession.institution_identifiers_get
         )
         assert endpoint_args == method_args
 

--- a/tests/webtests/test_metadata_api_live.py
+++ b/tests/webtests/test_metadata_api_live.py
@@ -429,6 +429,77 @@ class TestLiveMetadataSession:
             )
             assert response.json()["action"] == "Unset Holdings"
 
+    @pytest.mark.parametrize(
+        "argm,ids,symbols",
+        [
+            ("58122,13437", [58122, 13437], [["BKL"], ["NYP"]]),
+            ("58122, 13437", [58122, 13437], [["BKL"], ["NYP"]]),
+            (["58122", 13437], [58122, 13437], [["BKL"], ["NYP"]]),
+            (["58122", "13437"], [58122, 13437], [["BKL"], ["NYP"]]),
+            ([58122, 13437], [58122, 13437], [["BKL"], ["NYP"]]),
+            (58122, [58122], [["NYP"]]),
+            ("58122", [58122], [["NYP"]]),
+            ([58122], [58122], [["NYP"]]),
+        ],
+    )
+    def test_institution_indentifiers_get_registry_ids(
+        self, live_token, argm, ids, symbols
+    ):
+        with MetadataSession(authorization=live_token, totalRetries=2) as session:
+            response = session.institution_indentifiers_get(registryIds=argm)
+            assert (
+                "https://metadata.api.oclc.org/worldcat/search/institution?registryIds="
+                in response.url
+            )
+            assert response.status_code == 200
+            assert list(response.json().keys()) == ["entries"]
+            assert sorted(list(response.json()["entries"][0].keys())) == sorted(
+                [
+                    "oclcSymbols",
+                    "registryId",
+                ]
+            )
+            assert sorted(
+                [i["registryId"] for i in response.json()["entries"]]
+            ) == sorted(ids)
+            assert sorted(
+                [i["oclcSymbols"] for i in response.json()["entries"]]
+            ) == sorted(symbols)
+
+    @pytest.mark.parametrize(
+        "argm,ids,symbols",
+        [
+            ("BKL,NYP", [58122, 13437], [["BKL"], ["NYP"]]),
+            ("BKL, NYP", [58122, 13437], [["BKL"], ["NYP"]]),
+            (["BKL", "NYP"], [58122, 13437], [["BKL"], ["NYP"]]),
+            ("BKL", [13437], [["BKL"]]),
+            (["BKL"], [13437], [["BKL"]]),
+        ],
+    )
+    def test_institution_indentifiers_get_oclc_symbols(
+        self, live_token, argm, ids, symbols
+    ):
+        with MetadataSession(authorization=live_token, totalRetries=2) as session:
+            response = session.institution_indentifiers_get(oclcSymbols=argm)
+            assert (
+                "https://metadata.api.oclc.org/worldcat/search/institution?oclcSymbols="
+                in response.url
+            )
+            assert response.status_code == 200
+            assert list(response.json().keys()) == ["entries"]
+            assert sorted(list(response.json()["entries"][0].keys())) == sorted(
+                [
+                    "oclcSymbols",
+                    "registryId",
+                ]
+            )
+            assert sorted(
+                [i["registryId"] for i in response.json()["entries"]]
+            ) == sorted(ids)
+            assert sorted(
+                [i["oclcSymbols"] for i in response.json()["entries"]]
+            ) == sorted(symbols)
+
     def test_shared_print_holdings_search(self, live_token):
         with MetadataSession(authorization=live_token, totalRetries=2) as session:
             response = session.shared_print_holdings_search(oclcNumber="41266045")

--- a/tests/webtests/test_metadata_api_live.py
+++ b/tests/webtests/test_metadata_api_live.py
@@ -442,11 +442,11 @@ class TestLiveMetadataSession:
             ([58122], [58122], [["NYP"]]),
         ],
     )
-    def test_institution_indentifiers_get_registry_ids(
+    def test_institution_identifiers_get_registry_ids(
         self, live_token, argm, ids, symbols
     ):
         with MetadataSession(authorization=live_token, totalRetries=2) as session:
-            response = session.institution_indentifiers_get(registryIds=argm)
+            response = session.institution_identifiers_get(registryIds=argm)
             assert (
                 "https://metadata.api.oclc.org/worldcat/search/institution?registryIds="
                 in response.url
@@ -476,11 +476,11 @@ class TestLiveMetadataSession:
             (["BKL"], [13437], [["BKL"]]),
         ],
     )
-    def test_institution_indentifiers_get_oclc_symbols(
+    def test_institution_identifiers_get_oclc_symbols(
         self, live_token, argm, ids, symbols
     ):
         with MetadataSession(authorization=live_token, totalRetries=2) as session:
-            response = session.institution_indentifiers_get(oclcSymbols=argm)
+            response = session.institution_identifiers_get(oclcSymbols=argm)
             assert (
                 "https://metadata.api.oclc.org/worldcat/search/institution?oclcSymbols="
                 in response.url


### PR DESCRIPTION
### Added
 - Added support for `/worldcat/search/institution` endpoint:
   - `MetadataSession.institution_identifiers_get()` allows users to retrieve retrieve the Registry ID and OCLC Symbols for one or more institutions (part of #127)
 - Added `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API

### Fixed
 - minor typos in docstrings within `MetadataSession`