### PR TITLE
Move holdings endpoint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
  - Added support for new new Metadata API functionality:
    - `MetadataSession.branch_holding_codes_get()` allows users to retrieve branch holding codes and shelving locations using the `/worldcat/manage/institution-config/branch-shelving-locations` endpoint
    - `MetadataSession.institution_identifiers_get()` allows users to retrieve retrieve the Registry ID and OCLC Symbols for one or more institutions using the `/worldcat/search/institution` endpoint
+   - `MetadataSession.holdings_move()` allows users to move holdings and all associated LHR and LBD records from one bib record to another using the `/worldcat/manage/institution/holdings/move` endpoint
  - Added `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API
 
 ### Changed

--- a/docs/manage_holdings.md
+++ b/docs/manage_holdings.md
@@ -212,3 +212,39 @@ Beginning in September 2024 users are able to remove associated Local Bibliograp
       "action": "Unset Holdings"
     }
     ```
+
+## Move Holdings
+Users can move holdings from one bibliographic record to another using the `holdings_move` method. This method takes two OCLC numbers: one for the source record on which the holdings are currently set, and one for the target record to which the holdings should be moved. Using the `holdings_move` method will also move all associated Local Bibliographic Data and Local Holdings Records from the source record to the target.
+
+```python title="holdings_move Request"
+from bookops_worldcat import MetadataSession
+
+with MetadataSession(authorization=token) as session:
+    response = session.holdings_move(sourceOclcNumber=12345, targetOclcNumber=67890)
+    print(response.json())
+```
+```{ .json title="holdings_move Response" .no-copy}
+[
+  {
+    "sourceControlNumber": "12345"
+  },
+  {
+    "requestedSourceControlNumber": "12345"
+  },
+  {
+    "targetControlNumber": "67890"
+  },
+  {
+    "requestedTargetControlNumber": "67890"
+  },
+  {
+    "success": true
+  },
+  {
+    "message": "Successfully set holding and moved local bibliographic data (LBD) and local holdings records (LHRs) to bibliographic record 67890."
+  },
+  {
+    "action": "Move Holdings"
+  }
+]
+```

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -732,6 +732,10 @@ class TestMockedMetadataSession:
     def test_summary_holdings_search(self, stub_session, mock_session_response):
         assert stub_session.summary_holdings_search(oclcNumber=12345).status_code == 200
 
+    @pytest.mark.http_code(200)
+    def test_summary_holdings_search_isbn(self, stub_session, mock_session_response):
+        assert stub_session.summary_holdings_search(isbn=12345).status_code == 200
+
     def test_summary_holdings_search_invalid_oclc_number(self, stub_session):
         msg = "Argument 'oclcNumber' does not look like real OCLC #."
         with pytest.raises(InvalidOclcNumber) as exc:
@@ -744,6 +748,12 @@ class TestMockedMetadataSession:
             stub_session.shared_print_holdings_search(oclcNumber=12345).status_code
             == 200
         )
+
+    @pytest.mark.http_code(200)
+    def test_shared_print_holdings_search_isbn(
+        self, stub_session, mock_session_response
+    ):
+        assert stub_session.shared_print_holdings_search(isbn=12345).status_code == 200
 
     def test_shared_print_holdings_search_with_invalid_oclc_number_passed(
         self, stub_session

--- a/tests/test_metadata_api.py
+++ b/tests/test_metadata_api.py
@@ -96,6 +96,12 @@ class TestMockedMetadataSession:
             == "https://metadata.api.oclc.org/worldcat/manage/institution/holdings/current"
         )
 
+    def test_url_manage_ih_move(self, stub_session):
+        assert (
+            stub_session._url_manage_ih_move()
+            == "https://metadata.api.oclc.org/worldcat/manage/institution/holdings/move"
+        )
+
     def test_url_manage_ih_set(self, stub_session):
         assert (
             stub_session._url_manage_ih_set(oclcNumber="12345")
@@ -475,6 +481,25 @@ class TestMockedMetadataSession:
         assert "Too many OCLC Numbers passed to 'oclcNumbers' argument." in str(
             exc.value
         )
+
+    @pytest.mark.http_code(200)
+    def test_holdings_move(self, stub_session, mock_session_response):
+        assert (
+            stub_session.holdings_move(
+                sourceOclcNumber=850940548, targetOclcNumber=850933140
+            ).status_code
+            == 200
+        )
+
+    def test_holdings_move_no_oclcNumber_passed(self, stub_session):
+        with pytest.raises(TypeError):
+            stub_session.holdings_move()
+
+    def test_holdings_move_None_oclcNumber_passed(self, stub_session):
+        with pytest.raises(InvalidOclcNumber):
+            stub_session.holdings_move(
+                sourceOclcNumber=850940548, targetOclcNumber=None
+            )
 
     @pytest.mark.http_code(201)
     def test_holdings_set(self, stub_session, mock_session_response):


### PR DESCRIPTION
### Added
 - `MetadataSession.holdings_move()` allows users to move holdings and all associated LHR and LBD records from one bib record to another using the `/worldcat/manage/institution/holdings/move` endpoint
   - this method does not have any live tests because a record must have LHR and/or LBD records associated with it in order to move holdings from the record to another using this endpoint
 - added additional tests for `MetadataSession.shared_print_holdings_search()` and `MetadataSession.summary_holdings_search()` to bring branch coverage up to 100%