### PR TITLE
New publishing workflows

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,32 @@
+name: deploy-docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-docs:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Poetry with pipx
+        run: pipx install poetry
+      - name: Install dependencies with poetry
+        run: poetry install --no-root --without dev
+      - name: Get version number          
+        run: echo "version=$(poetry version -s | cut -d. -f1,2)" >> $GITHUB_ENV          
+      - name: Deploy docs to GitHub pages site
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN}}
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          poetry run mike deploy ${{ env.version }} latest --push
+          poetry run mike set-default ${{ env.version }} --push

--- a/.github/workflows/monthly-api-tests.yaml
+++ b/.github/workflows/monthly-api-tests.yaml
@@ -7,28 +7,19 @@ on:
   schedule: 
     - cron: '0 5 15 * *'
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  GH_REPO: ${{ github.repository }}
   WCKey: ${{ secrets.WC_KEY }}
   WCSecret: ${{ secrets.WC_SECRET }}
   WCScopes: "WorldCatMetadataAPI"
 jobs:
   webtests:
     name: Run live webtests
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' && contains(fromJSON(vars.MAINTAINERS), github.actor) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Check if PR is from fork
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
-            echo "is_fork=true" >> $GITHUB_ENV
-          else
-            echo "is_fork=false" >> $GITHUB_ENV
-          fi
       - name: Set up Python ${{ matrix.python-version}}
         uses: actions/setup-python@v5
         with:
@@ -36,10 +27,6 @@ jobs:
       - name: Install Poetry with pipx
         run: pipx install poetry          
       - name: Install dependencies
-        if: ${{ env.is_fork == 'false' || github.event_name == 'schedule' }}
-        run: |
-          poetry install --no-root --without docs
+        run: poetry install --no-root --without docs
       - name: Run monthly live tests
-        if: ${{ env.is_fork == 'false' || github.event_name == 'schedule' }}
-        run: |
-          poetry run pytest -m "webtest"     
+        run: poetry run pytest -m "webtest"     

--- a/.github/workflows/monthly-api-tests.yaml
+++ b/.github/workflows/monthly-api-tests.yaml
@@ -1,4 +1,4 @@
-name: monthly API response check
+name: live-tests
 on: 
   pull_request:
     branches:
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Check if PR is from fork

--- a/.github/workflows/monthly-api-tests.yaml
+++ b/.github/workflows/monthly-api-tests.yaml
@@ -15,15 +15,12 @@ jobs:
     name: Run live webtests
     if: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' && contains(fromJSON(vars.MAINTAINERS), github.actor) }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version}}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version}}
+          python-version: "3.13"
       - name: Install Poetry with pipx
         run: pipx install poetry          
       - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,91 @@
+name: publish
+
+on:
+  push:
+    branches: 
+      - publish-workflows
+  release:
+    types: [published, created, edited]
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Poetry with pipx
+        run: pipx install poetry
+      - name: Install dependencies with poetry
+        run: poetry install --no-root --without docs
+      - name: Run tests
+        run: poetry run pytest -m "not webtest" --cov=bookops_worldcat/
+  deploy-docs:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    # permissions:
+    #   contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Poetry with pipx
+        run: pipx install poetry
+      - name: Install dependencies with poetry
+        run: poetry install --no-root --without dev
+      - name: Get version number          
+      - run: echo "version=$(poetry version -s)" >> $GITHUB_ENV          
+      - name: Deploy docs to GitHub pages site
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN}}
+        run: |
+          echo "git config --global user.name '${{ github.actor }}'"
+          echo "git config --global user.email '${{ github.actor }}@users.noreply.github.com'"
+          echo "poetry run mike deploy ${{ env.version }} latest --push"
+          echo "poetry run mike set-default ${{ env.version }} --push"
+  build-release:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Poetry with pipx
+        run: pipx install poetry
+
+      - name: Install dependencies with poetry
+        run: poetry install --no-root --without dev,docs
+      
+      - name: Build package distributions
+        run: poetry build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: bookops-worldcat-distributions-test
+          path: dist/
+          if-no-files-found: error
+
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-release
+    # permissions:
+    #   id-token: write
+    steps:
+      - name: Retrieve distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: bookops-worldcat-distributions-test
+          path: dist/    
+      - name: Confirm files were retrieved
+        run: ls -R dist/
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1        

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,8 @@
 name: publish
 
 on:
-  push:
-    branches: 
-      - publish-workflows
   release:
-    types: [published, created, edited]
+    types: [published]
 
 jobs:
   test:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,6 +50,7 @@ jobs:
   build-release:
     name: Build distributions
     runs-on: ubuntu-latest
+    environment: deployment
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -75,6 +76,7 @@ jobs:
   pypi-publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi    
     needs: build-release
     permissions:
       id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies with poetry
         run: poetry install --no-root --without dev
       - name: Get version number          
-      - run: echo "version=$(poetry version -s)" >> $GITHUB_ENV          
+        run: echo "version=$(poetry version -s)" >> $GITHUB_ENV          
       - name: Deploy docs to GitHub pages site
         env:
           github-token: ${{ secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,54 +5,13 @@ on:
     types: [published]
 
 jobs:
-  test:
-    name: Run unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install Poetry with pipx
-        run: pipx install poetry
-      - name: Install dependencies with poetry
-        run: poetry install --no-root --without docs
-      - name: Run tests
-        run: poetry run pytest -m "not webtest" --cov=bookops_worldcat/
-  
-  deploy-docs:
-    name: Deploy docs to GitHub Pages
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install Poetry with pipx
-        run: pipx install poetry
-      - name: Install dependencies with poetry
-        run: poetry install --no-root --without dev
-      - name: Get version number          
-        run: echo "version=$(poetry version -s | cut -d. -f1,2)" >> $GITHUB_ENV          
-      - name: Deploy docs to GitHub pages site
-        env:
-          github-token: ${{ secrets.GITHUB_TOKEN}}
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-          poetry run mike deploy ${{ env.version }} latest --push
-          poetry run mike set-default ${{ env.version }} --push
-
   build-release:
     name: Build distributions
     runs-on: ubuntu-latest
-    environment: deployment
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -73,10 +32,12 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  pypi-publish:
+  publish-to-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    environment: pypi    
+    environment: 
+      name: pypi
+      url: https://pypi.org/project/bookops-worldcat    
     needs: build-release
     permissions:
       id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,11 +20,12 @@ jobs:
         run: poetry install --no-root --without docs
       - name: Run tests
         run: poetry run pytest -m "not webtest" --cov=bookops_worldcat/
+  
   deploy-docs:
     name: Deploy docs to GitHub Pages
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: write
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -36,15 +37,16 @@ jobs:
       - name: Install dependencies with poetry
         run: poetry install --no-root --without dev
       - name: Get version number          
-        run: echo "version=$(poetry version -s)" >> $GITHUB_ENV          
+        run: echo "version=$(poetry version -s | cut -d. -f1,2)" >> $GITHUB_ENV          
       - name: Deploy docs to GitHub pages site
         env:
           github-token: ${{ secrets.GITHUB_TOKEN}}
         run: |
-          echo "git config --global user.name '${{ github.actor }}'"
-          echo "git config --global user.email '${{ github.actor }}@users.noreply.github.com'"
-          echo "poetry run mike deploy ${{ env.version }} latest --push"
-          echo "poetry run mike set-default ${{ env.version }} --push"
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          poetry run mike deploy ${{ env.version }} latest --push
+          poetry run mike set-default ${{ env.version }} --push
+
   build-release:
     name: Build distributions
     runs-on: ubuntu-latest
@@ -66,7 +68,7 @@ jobs:
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: bookops-worldcat-distributions-test
+          name: bookops-worldcat-distributions
           path: dist/
           if-no-files-found: error
 
@@ -74,15 +76,13 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: build-release
-    # permissions:
-    #   id-token: write
+    permissions:
+      id-token: write
     steps:
       - name: Retrieve distributions
         uses: actions/download-artifact@v4
         with:
-          name: bookops-worldcat-distributions-test
+          name: bookops-worldcat-distributions
           path: dist/    
-      - name: Confirm files were retrieved
-        run: ls -R dist/
-      # - name: Publish package distributions to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1        
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,17 +25,19 @@ jobs:
       - name: Install dependencies with poetry
         run: poetry install --no-root --without docs
       - name: Run tests
-        run: poetry run pytest -m "not webtest" --cov=bookops_worldcat/
+        run: poetry run pytest -m "not webtest" --cov=bookops_worldcat/ --cov-report=xml
       - name: Send report to Coveralls
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           parallel: true
           github-token: ${{ secrets.GITHUB_TOKEN}}
+          flag-name: ${{ matrix.python-version}}
+
   finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
+      - name: Coveralls finished
+        uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version}}

--- a/bookops_worldcat/__version__.py
+++ b/bookops_worldcat/__version__.py
@@ -1,4 +1,4 @@
 __title__ = "bookops-worldcat"
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 __author__ = "Tomasz Kalata"
 __author_email__ = "klingaroo@gmail.com"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -339,6 +339,6 @@ types-requests==2.32.0.20241016 ; python_version >= "3.9" \
 typing-extensions==4.12.2 ; python_version >= "3.9" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
-urllib3==2.2.3 ; python_version >= "3.9" \
-    --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
-    --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9
+urllib3==2.5.0 ; python_version >= "3.9" \
+    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
+    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
    - `MetadataSession.institution_identifiers_get()` allows users to retrieve retrieve the Registry ID and OCLC Symbols for one or more institutions using the `/worldcat/search/institution` endpoint
    - `MetadataSession.holdings_move()` allows users to move holdings and all associated LHR and LBD records from one bib record to another using the `/worldcat/manage/institution/holdings/move` endpoint
  - Added `verify_ids` function in `utils.py` to check OCLC Symbols and Registry IDs before passing values to API
+ - GitHub Actions workflows to publish new versions to PyPI (`publish.yaml`) and deploy docs to [bookops-cat.github.io/bookops-worldcat/](bookops-cat.github.io/bookops-worldcat/) (`deploy-docs.yaml`) when a new release is published
 
 ### Changed
  - restructured `pyproject.toml` following the changes implemented with poetry 2.0. Several sections of the `pyproject.toml` file have been moved from the `tool.poetry` section to the `project` section. 
@@ -20,6 +21,7 @@
    - `coverage` (7.9.1)
    - `pytest` (8.4.0)
    - `pytest-cov` (6.2.1)
+   - `urllib3` (2.5.0)
    - made `types-requests` a required dependency
  - updated `tool.pytest.ini_options` section to include coverage options
  - updated `tool.coverage.run` to omit `tests` and `docs` paths from coverage report 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -88,7 +88,7 @@ python -m pytest "not webtest" --cov=bookops_worldcat/
 ```
 
 ### Release Checklist
-Any major or minor updates should get a new release in GitHub. Use the following checklist when getting a new update ready for release. For patch updates/bug fixes, follow steps 1-4.
+Any updates should get a new release in GitHub. Use the following checklist when getting a new update ready for release. For patch updates/bug fixes, follow steps 1-4.
 
 1. Verify `poetry.lock`, `pyproject.toml`, `requirements.txt`, and `dev-requirements.txt` files are up-to-date
      * **`poetry check`** to check that the contents of the `poetry.lock` and `pyproject.toml` files are consistent
@@ -105,10 +105,12 @@ Any major or minor updates should get a new release in GitHub. Use the following
     * Merge all changes from `releases/v[version]` into main 
 4. Create a new github release
     * At minimum, include information from changelog in release. Include additional details about changes as appropriate.   
-    * On publish, the `publish.yaml` workflow will run which will:
-      * Build a new version of the docs and deploy them to the GitHub pages site
-        * **`mike deploy [version] [alias] --push`** to deploy docs
-        * **`mike set-default [version]`** to set new version to default
-      * Build the source and wheels archive using `poetry`
-        * **`poetry build`**
-      * Publish the new version of the package to PyPI using trusted publishing
+    * On publish, the `publish.yaml` and `deploy-docs.yaml` workflows will run. These workflows will publish the latest version of the pack to PyPI and deploy the latest version of the GitHub pages docs.
+      * `deploy-docs.yaml`
+        * Builds a new version of the docs and deploys them to the GitHub pages site.
+            * **`mike deploy [version] [alias] --push`** to deploy docs
+            * **`mike set-default [version]`** to set new version to default
+      * `publish.yaml`
+        * Builds the source and wheels archive using `poetry`.
+            * **`poetry build`**
+        * Publishes the new version of the package to PyPI using trusted publishing.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,7 +52,7 @@ For new code contributions, please use the tools and standards in place for Book
 ### Install and Setup
 To get started contributing code to Bookops-Worldcat you will need: 
 
- + Python 3.8 or newer
+ + Python 3.9 or newer
  + `git`
  + [`poetry`](https://python-poetry.org/docs/#installation)
 
@@ -91,24 +91,24 @@ python -m pytest "not webtest" --cov=bookops_worldcat/
 Any major or minor updates should get a new release in GitHub. Use the following checklist when getting a new update ready for release. For patch updates/bug fixes, follow steps 1-4.
 
 1. Verify `poetry.lock`, `pyproject.toml`, `requirements.txt`, and `dev-requirements.txt` files are up-to-date
-     * **`poetry check`** to check that `poetry.lock` and `pyproject.toml` files are in sync 
-     * **`poetry update`** to update all packages 
-     * or **`poetry update [package1] [ package2]`** to update packages individually
-     * **`poetry install`** to install all versions of packages listed in the `pyproject.toml` file
+     * **`poetry check`** to check that the contents of the `poetry.lock` and `pyproject.toml` files are consistent
+     * **`poetry sync`** will update your local virtual environment to ensure if is in sync with the poetry.lock file and install/uninstall packages as necessary.
      * Export `requirements.txt` files with [poetry-plugin-export](https://github.com/python-poetry/poetry-plugin-export)
-2. Update documentation
-    * Update changelog: include version, date, and descriptions of changes
-    * Update links within docs if OCLC has made any changes
+       * **`poetry export -f requirements.txt --output requirements.txt`**
+       * **`poetry export -f requirements.txt --with dev --output dev-requirements.txt`**       
+2. Review documentation to ensure it has been updated with recent changes
+    * Review changelog to ensure version, date, and descriptions of changes are correct
+    * Review pertinent documentation for GitHub pages site to confirm it has been updated with any changes from this release. 
+    * Update links within docs if OCLC has made any changes to their documentation. 
+    * Check that the package version has been updated in `__version__.py`, `tests/test_version.py` and `pyproject.toml`
 3. Commit changes to repo
-    * Merge all changes into `release/v[version]` branch
-    * Ensure tests have run and passed within GitHub Actions
-4. Rebuild docs using mike:
-    * **`mike --rebase`** to fetch remote version of docs to your local branch (optional)
-    * **`mike deploy [version] [alias] --push`** to deploy docs
-    * **`mike set-default [version]`** to set new version to default
-5. Create a new github release
-    * At minimum, include information from changelog in release. Include additional details about changes as appropriate.
-6. Build package in poetry
-    * **`poetry build`**
-7. Publish to PyPI
-    * **`poetry publish`**
+    * Merge all changes from `releases/v[version]` into main 
+4. Create a new github release
+    * At minimum, include information from changelog in release. Include additional details about changes as appropriate.   
+    * On publish, the `publish.yaml` workflow will run which will:
+      * Build a new version of the docs and deploy them to the GitHub pages site
+        * **`mike deploy [version] [alias] --push`** to deploy docs
+        * **`mike set-default [version]`** to set new version to default
+      * Build the source and wheels archive using `poetry`
+        * **`poetry build`**
+      * Publish the new version of the package to PyPI using trusted publishing

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Bookops-Worldcat version 1.0 supports changes released in version 2.0 (May 2023)
 
 ## Overview
 
-Requires Python 3.8 and up.
+Requires Python 3.9 and up.
 
 Bookops-Worldcat takes advantage of the functionality of the popular [Requests library](https://requests.readthedocs.io/) and interactions with OCLC's services are built around 'Requests' sessions. `MetadataSession` inherits all `requests.Session` properties. Server responses are `requests.Response` objects with [all of their properties and methods](https://requests.readthedocs.io/en/latest/user/quickstart/).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,11 +76,7 @@ plugins:
           import:
             - https://docs.python.org/3/objects.inv
   - mike:
-      version_selector: true   # set to false to leave out the version selector
-      css_dir: css             # the directory to put the version selector's CSS
-      javascript_dir: js       # the directory to put the version selector's JS
-      canonical_version: null  # the version for <link rel="canonical">; `null`
-                               # uses the version specified via `mike deploy`
+      canonical_version: latest
 extra:
   version:
     provider: mike

--- a/poetry.lock
+++ b/poetry.lock
@@ -1241,14 +1241,14 @@ markers = {docs = "python_version < \"3.10\""}
 
 [[package]]
 name = "urllib3"
-version = "2.2.3"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "docs"]
 files = [
-    {file = "urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac"},
-    {file = "urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,6 +116,6 @@ requests==2.32.4 ; python_version >= "3.9" \
 types-requests==2.32.0.20241016 ; python_version >= "3.9" \
     --hash=sha256:0d9cad2f27515d0e3e3da7134a1b6f28fb97129d86b867f24d9c726452634d95 \
     --hash=sha256:4195d62d6d3e043a4eaaf08ff8a62184584d2e8684e9d2aa178c7915a7da3747
-urllib3==2.2.3 ; python_version >= "3.9" \
-    --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
-    --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9
+urllib3==2.5.0 ; python_version >= "3.9" \
+    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
+    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,15 +2,15 @@
 
 
 from bookops_worldcat.__version__ import (
-    __version__,
-    __title__,
     __author__,
     __author_email__,
+    __title__,
+    __version__,
 )
 
 
 def test_version():
-    assert __version__ == "1.1.1"
+    assert __version__ == "1.2.0"
 
 
 def test_title():


### PR DESCRIPTION
### Added:
 - `deploy-docs.yaml` workflow to deploy newest version of docs to github pages site when a new release is published
 - `publish.yaml` workflow to build source and wheels and publish to PyPI using trusted publishing. more info on this workflow is available here: 
     - https://docs.pypi.org/trusted-publishers/using-a-publisher/
     - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
### Changed: 
  - renamed workflow in `monthly-api-tests.yaml` for clarity. this workflow runs on a schedule and on PRs from maintainers
  - logic in `monthly-api-tests.yaml` that determined whether or not to run live tests for a PR. The workflow now checks to see if the user who triggered the workflow is in the repository's `MAINTAINERS` envar
  - replaced `AndreMiras/coveralls-python-action@develop` action from `unit-tests.yaml` with `coverallsapp/github-action@v2` as it is more actively maintained and maintained by coveralls
  - `urllib3` updated to 2.5.0 due to dependabot PR
  - version number in `__version__.py`
  - updated Release Checklist in docs `contributing.md` to reflect new publishing workflows

### Removed:
 - python 3.8 from tests in GitHub actions
 - unused `mike` options in `mkdocs.yml`